### PR TITLE
Add tokyo-night theme

### DIFF
--- a/public/css/themes/tokyo-night.css
+++ b/public/css/themes/tokyo-night.css
@@ -1,0 +1,8 @@
+html {
+  background-image: url("https://i.imgur.com/WBXk3bs.gif");
+}
+
+body {
+  /*Opacity of background itself */
+  background-color: rgba(0, 0, 0, 0.75);
+}

--- a/public/css/themes/tokyo-night.css
+++ b/public/css/themes/tokyo-night.css
@@ -15,6 +15,8 @@ body {
 #title {
   font-family: 'chikara-dzuyoku-b', serif;
   font-style: italic;
+  font-weight: 400;
+  transform: scale(1.5, 1.7) translateY(-.2em);
 }
 
 #subtitle {

--- a/public/css/themes/tokyo-night.css
+++ b/public/css/themes/tokyo-night.css
@@ -1,3 +1,8 @@
+@font-face {
+  font-family: chikara-dzuyoku-b;
+  src: url(/css/fonts/851CHIKARA-DZUYOKU_kanaB.ttf);
+}
+
 html {
   background-image: url("https://i.imgur.com/WBXk3bs.gif");
 }
@@ -5,4 +10,13 @@ html {
 body {
   /*Opacity of background itself */
   background-color: rgba(0, 0, 0, 0.75);
+}
+
+#title {
+  font-family: 'chikara-dzuyoku-b', serif;
+  font-style: italic;
+}
+
+#subtitle {
+  font-family: 'chikara-dzuyoku-b', serif;
 }

--- a/public/index.html
+++ b/public/index.html
@@ -82,8 +82,9 @@
         <div class="dropdown-content">
           <button type="button" class="themeChoice" id="chicagoEvening">Chicago Evening</button>
           <button type="button" class="themeChoice" id="cyberpunkBartender">Cyberpunk Bartender</button>
-          
+
           <button type="button" class="themeChoice" id="yorha">YoRHa</button>
+          <button type="button" class="themeChoice" id="tokyoNight">Tokyo Night</button>
           <!--
           <button type="button" class="themeChoice" id="minimalist">Minimalist</button>
           <button type="button" class="themeChoice" id="electromaster">Electromaster</button>

--- a/public/js/theme.json
+++ b/public/js/theme.json
@@ -102,7 +102,7 @@ var theme = {
   "tokyoNight": {
     "cssPath": "/css/themes/tokyo-night.css",
     "title": "ケイデンス",
-    "subtitle": "リズミカルな経験",
+    "subtitle": "リズミカルな体験",
     "themeColor": "#0e1428",
     "themeColorRead": "#0e1428 even darker navy",
     "themeKey": "tokyoNight"

--- a/public/js/theme.json
+++ b/public/js/theme.json
@@ -98,5 +98,13 @@ var theme = {
     "themeColor": "#000000",
     "themeColorRead": "#000000 black",
     "themeKey": "minimalistDark"
+  },
+  "tokyoNight": {
+    "cssPath": "/css/themes/tokyo-night.css",
+    "title": "ケイデンス",
+    "subtitle": "リズミカルな経験",
+    "themeColor": "#0e1428",
+    "themeColorRead": "#0e1428 even darker navy",
+    "themeKey": "tokyoNight"
   }
 }


### PR DESCRIPTION
This theme uses the `tokyo-night.gif` image found in old versions of Cadence (actually, that found at the time of the removal of Space Station), uploaded to Imgur to comply with current practice.

See my notes on 45ea882 for a description of the title and subtitle.

The font used for the title and subtitle is the same used in electromaster (and by extension, Star Guardian) - That being "chikara-dzuyoku-b" (found in the 'fonts' folder as `851CHIKARA-DZUYOKU_kanaB.ttf`).

I'm not sure whether @kenellorando would want this theme to be available, but I've always liked it, so now that I remembered the file for it was there I'm submitting a PR to add it.

For reference, on my laptop, `tokyo-night` looks like a less cropped version of this:

![image](https://user-images.githubusercontent.com/15851480/34766304-93e7f1fe-f5b9-11e7-84d5-5ad097cde726.png)
