### PR TITLE
Escape special characters in song path HTML

### DIFF
--- a/public/js/aria.js
+++ b/public/js/aria.js
@@ -49,7 +49,7 @@ $(document).ready(function () {
             i++;
             console.log("=================");
             */
-            table += "<tr><td class='dataTitle'>" + song.title + "</td><td class='dataArtist'>" + song.artist + "</td><td class='dataRequest'><button class='requestButton' data-path='" + song.path + "'>REQUEST</button></td></tr>";
+            table += "<tr><td class='dataTitle'>" + song.title + "</td><td class='dataArtist'>" + song.artist + "</td><td class='dataRequest'><button class='requestButton' data-path='" + escape(song.path) + "'>REQUEST</button></td></tr>";
           })
         } else {
           console.log("CADENCE: Database query completed.  0 results found. :(");
@@ -73,7 +73,7 @@ $(document).ready(function () {
     // console.log(this.dataset.path); // /home/ken/Music/fripSide/01. only my railgun.mp3
 
     var data = {};
-    data.path = this.dataset.path;
+    data.path = unescape(this.dataset.path);
 
     // so when you click a working button, change it to red and disable it
 


### PR DESCRIPTION
#74 was caused by the browser interpreting the single-quote in "sister's noise" as ending the "data-path" attribute on the request button, thus cutting off the path.

This is fixed by escaping special characters in the path before writing them to the HTML, then unescaping them before they go to the server. The server therefore has no idea that anything has changed, but characters the browser might misinterpret in an attribute go away.

This pull request fixes #74.