### PR TITLE
Re-add creepy cadence

### DIFF
--- a/public/css/themes/creepy-cadence.css
+++ b/public/css/themes/creepy-cadence.css
@@ -446,3 +446,9 @@ a:active {
     margin-bottom: .4em;
   }
 }
+
+@media (max-width: 63em) {
+  #title {
+    transform: scale(1, 1.2);
+  }
+}

--- a/public/css/themes/creepy-cadence.css
+++ b/public/css/themes/creepy-cadence.css
@@ -1,0 +1,436 @@
+@import url('https://fonts.googleapis.com/css?family=Bellefair');
+@import url('https://fonts.googleapis.com/css?family=Butcherman');
+
+html {
+  background-color: black;
+  background-image: url(https://i.imgur.com/g5k4dB0.jpg);
+  background-size: cover;
+  background-position: top;
+  opacity: 1;
+}
+
+body {
+  /*Opacity of content within body*/
+  opacity: 1;
+  /*Opacity of background itself */
+  background: rgba(0, 0, 0, 0.2);
+  /* Dark color for text */
+  color:white;
+  text-transform: uppercase;
+}
+
+#player {
+  font-family: 'Bellefair', serif;
+  font-style: normal;
+}
+
+#positioner {
+  position: relative;
+  width: auto;
+  height: auto;
+  display: inline-block;
+}
+
+#title{
+  font-family: 'Bellefair', serif;
+  text-transform: lowercase;
+  font-weight: 500;
+  transform: scale(1.4, 1.6);
+  margin-top: -2em;
+}
+
+#subtitle span {
+  display: inline-block;
+  animation-play-state: running;
+  animation-iteration-count: infinite;
+  animation-duration: 100s;
+  animation-timing-function: steps(10000, start);
+  animation-name: subtitleglitch;
+}
+
+#positioner>h1 {
+  animation-play-state: running;
+  animation-iteration-count: infinite;
+  animation-duration: 100s;
+  animation-timing-function: steps(10000, start);
+}
+
+#positioner>h1:not(#titlecontainer) {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+}
+
+#hiddentitle {
+  animation-name: hiddentitleglitch;
+}
+
+#titlewithakay {
+  animation-name: karenglitch;
+}
+
+#titlecontainer {
+  animation-name: titleglitch;
+}
+
+#deadtitle {
+  animation-name: deadglitch;
+}
+
+#titledeath {
+  animation-name: deathglitch;
+}
+
+#sortedtitle {
+  animation-name: sortedglitch;
+}
+
+#phonetictitle {
+  animation-name: phoneticglitch;
+}
+
+#title span {
+  text-transform: lowercase;
+  animation-play-state: running;
+  animation-timing-function: steps(100, start);
+  animation-iteration-count: infinite;
+  animation-name: glitch;
+}
+
+#title span:nth-of-type(1) {
+  animation-duration: 10s;
+}
+
+#title span:nth-of-type(2) {
+  animation-duration: 3s;
+}
+
+#title span:nth-of-type(3) {
+  animation-duration: 13s;
+}
+
+#title span:nth-of-type(4) {
+  animation-duration: 7s;
+}
+
+#title span:nth-of-type(5) {
+  animation-duration: 23s;
+}
+
+#title span:nth-of-type(6) {
+  animation-duration: 37s;
+}
+
+#title span:nth-of-type(7) {
+  animation-duration: 11s;
+}
+
+@keyframes glitch {
+  0% {
+    text-transform: lowercase;
+  }
+  94% {
+    text-transform: lowercase;
+  }
+  95% {
+    text-transform: uppercase;
+  }
+  99% {
+    text-transform: uppercase;
+  }
+  100% {
+    text-transform: lowercase;
+  }
+}
+
+@keyframes subtitleglitch {
+  0% {
+    font-family: inherit;
+    color: white;
+    font-size: 1em;
+    transform: none;
+  }
+  76.99% {
+    font-family: inherit;
+    color: white;
+    font-size: 1em;
+    transform: none;
+  }
+  77% {
+    font-family: 'Butcherman', cursive;
+    color: red;
+    font-size: 1.2em;
+    transform: scaleY(2);
+  }
+  77.49% {
+    font-family: 'Butcherman', cursive;
+    color: red;
+    font-size: 1.2em;
+    transform: scaleY(2);
+  }
+  77.5% {
+    font-family: inherit;
+    color: white;
+    font-size: 1em;
+    transform: none;
+  }
+  100% {
+    font-family: inherit;
+    color: white;
+    font-size: 1em;
+    transform: none;
+  }
+}
+
+@keyframes deadglitch {
+  0% {
+    opacity: 0;
+  }
+  8.49% {
+    opacity: 0;
+  }
+  8.5% {
+    opacity: 1;
+  }
+  10.99% {
+    opacity: 1;
+  }
+  11% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes hiddentitleglitch {
+  0% {
+    opacity: 0;
+  }
+  35.49% {
+    opacity: 0;
+  }
+  35.5% {
+    opacity: 1;
+  }
+  41.99% {
+    opacity: 1;
+  }
+  42% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes karenglitch {
+  0% {
+    opacity: 0;
+  }
+  48.49% {
+    opacity: 0;
+  }
+  48.5% {
+    opacity: 1;
+  }
+  49.99% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  98.49% {
+    opacity: 0;
+  }
+  98.5% {
+    opacity: 1;
+  }
+  99.99% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes deathglitch {
+  0% {
+    opacity: 0;
+  }
+  65.99% {
+    opacity: 0;
+  }
+  66% {
+    opacity: 1;
+  }
+  69.99% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes sortedglitch {
+  0% {
+    opacity: 0;
+  }
+  79.99% {
+    opacity: 0;
+  }
+  80% {
+    opacity: 1;
+  }
+  89.99% {
+    opacity: 1;
+  }
+  90% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes phoneticglitch {
+  0% {
+    opacity: 0;
+  }
+  94.99% {
+    opacity: 0;
+  }
+  95% {
+    opacity: 1;
+  }
+  98.49% {
+    opacity: 1;
+  }
+  98.5% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes titleglitch {
+  0% {
+    opacity: 1;
+  }
+  8.49% {
+    opacity: 1;
+  }
+  8.5% {
+    opacity: 0;
+  }
+  10.99% {
+    opacity: 0;
+  }
+  11% {
+    opacity: 1;
+  }
+  35.49% {
+    opacity: 1;
+  }
+  35.5% {
+    opacity: 0;
+  }
+  41.99% {
+    opacity: 0;
+  }
+  42% {
+    opacity: 1;
+  }
+  48.49% {
+    opacity: 1;
+  }
+  48.5% {
+    opacity: 0;
+  }
+  49.99% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  65.99% {
+    opacity: 1;
+  }
+  66% {
+    opacity: 0;
+  }
+  69.99% {
+    opacity: 0;
+  }
+  70% {
+    opacity: 1;
+  }
+  79.99% {
+    opacity: 1;
+  }
+  80% {
+    opacity: 0;
+  }
+  89.99% {
+    opacity: 0
+  }
+  90% {
+    opacity: 1;
+  }
+  94.99% {
+    opacity: 1;
+  }
+  95% {
+    opacity: 0;
+  }
+  99.99% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+#subtitle {
+  font-size: 1.6em;
+}
+
+#subtitle,
+#volumeLabel,
+.dropbtn,
+.dropdown-content button {
+  font-family: 'Bellefair', serif;
+  font-style: italic;
+}
+
+
+/* Link colors ************************/
+
+a:link {
+  color: lightgrey;
+}
+
+a:visited {
+  color: lightgrey;
+}
+
+a:hover {
+  color: grey;
+}
+
+a:active {
+  color: lightgrey;
+}
+
+#oldToggle {
+  color: lightgrey;
+}
+
+#oldToggle:hover {
+  color: grey;
+}

--- a/public/css/themes/creepy-cadence.css
+++ b/public/css/themes/creepy-cadence.css
@@ -36,8 +36,8 @@ body {
   text-transform: lowercase;
   font-weight: 500;
   transform: scale(1.4, 1.6);
-  padding-top: 0;
-  margin-top: -1em;
+  padding-top: .4em;
+  margin-top: -1.4em;
 }
 
 #subtitle span {

--- a/public/css/themes/creepy-cadence.css
+++ b/public/css/themes/creepy-cadence.css
@@ -36,8 +36,8 @@ body {
   text-transform: lowercase;
   font-weight: 500;
   transform: scale(1.4, 1.6);
-  padding-top: .4em;
-  margin-top: -1.4em;
+  padding-top: 0em;
+  margin-top: -1em;
 }
 
 #subtitle span {
@@ -450,5 +450,6 @@ a:active {
 @media (max-width: 63em) {
   #title {
     transform: scale(1, 1.2);
+    padding-top: .5em;
   }
 }

--- a/public/css/themes/creepy-cadence.css
+++ b/public/css/themes/creepy-cadence.css
@@ -36,7 +36,8 @@ body {
   text-transform: lowercase;
   font-weight: 500;
   transform: scale(1.4, 1.6);
-  margin-top: -2em;
+  margin-top: -2.5em;
+  margin-bottom: -.6em;
 }
 
 #subtitle span {

--- a/public/css/themes/creepy-cadence.css
+++ b/public/css/themes/creepy-cadence.css
@@ -36,8 +36,8 @@ body {
   text-transform: lowercase;
   font-weight: 500;
   transform: scale(1.4, 1.6);
-  margin-top: -2.5em;
-  margin-bottom: -.6em;
+  padding-top: 0;
+  margin-top: -1em;
 }
 
 #subtitle span {
@@ -434,4 +434,15 @@ a:active {
 
 #oldToggle:hover {
   color: grey;
+}
+
+@media (max-height: 50em) {
+  #title {
+    margin-top: -1.2em;
+    margin-bottom: -.3em;
+  }
+
+  #positioner h1 {
+    margin-bottom: .4em;
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -87,7 +87,7 @@
           <button type="button" class="themeChoice" id="yorha">YoRHa</button>
           <button type="button" class="themeChoice" id="spaceStation">Space Station</button>
           <button type="button" class="themeChoice" id="tokyoNight">Tokyo Night</button>
-          <button type="button" class="themeChoice" id="creepyCadence">Creepy Cadence"</button>
+          <button type="button" class="themeChoice" id="creepyCadence">Creepy Cadence</button>
 
           <!--
           <button type="button" class="themeChoice" id="minimalist">Minimalist</button>

--- a/public/index.html
+++ b/public/index.html
@@ -87,6 +87,7 @@
           <button type="button" class="themeChoice" id="yorha">YoRHa</button>
           <button type="button" class="themeChoice" id="spaceStation">Space Station</button>
           <button type="button" class="themeChoice" id="tokyoNight">Tokyo Night</button>
+          <button type="button" class="themeChoice" id="creepyCadence">Creepy Cadence"</button>
 
           <!--
           <button type="button" class="themeChoice" id="minimalist">Minimalist</button>

--- a/public/js/theme.json
+++ b/public/js/theme.json
@@ -147,5 +147,13 @@ var theme = {
     "themeColor": "#E4D9A3",
     "themeColorRead": "#E4D9A3 a pale yellow",
     "themeKey": "legacy"
+  },
+  "creepyCadence": {
+    "cssPath": "/css/themes/creepy-cadence.css",
+    "title": "<div id='positioner'><h1 id='titlecontainer'><span>c</span><span>a</span><span>d</span><span>e</span><span>n</span><span>c</span><span>e</span></h1><h1 id='hiddentitle'><span>c</span><span>a</span><span>e</span><span>n</span><span>c</span><span>d</span><span>e</span></h1><h1 id='titlewithakay'><span>k</span><span>a</span><span>d</span><span>e</span><span>n</span><span>c</span><span>e</span></h1><h1 id='deadtitle'><span>c</span><span>a</span><span>d</span><span>a</span><span>v</span><span>e</span><span>r</span></h1><h1 id='titledeath'><span>c</span><span>a</span><span>d</span><span>e</span><span>a</span><span>t</span><span>h</span></h1><h1 id='sortedtitle'><span>a</span><span>c</span><span>c</span><span>d</span><span>e</span><span>e</span><span>n</span></h1><h1 id='phonetictitle'><span>k</span><span>ay</span><span>d</span><span>e</span><span>n</span><span>s</span><span>e</span></h1></div>",
+    "subtitle": "A <span>Fun</span> Experience",
+    "themeColor": "#000000",
+    "themeColorRead": "#000000 black",
+    "themeKey": "creepyCadence"
   }
 }


### PR DESCRIPTION
See #104 for the full details of this PR.

Short screensize:

`creepy-cadence`

![image](https://user-images.githubusercontent.com/15851480/36286595-1396359a-1276-11e8-96ea-6b77f667e84e.png)

`chicago-evening`, on (roughly) the same axes:

![image](https://user-images.githubusercontent.com/15851480/36286491-9f032e90-1275-11e8-8675-a3d71c25ca86.png)

Mobile scale:

![image](https://user-images.githubusercontent.com/15851480/36286551-ef865e28-1275-11e8-899e-431c536e5552.png)
