### PR TITLE
Correct all paths for Cloudflare HTTPS proxy

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -50,7 +50,7 @@
 
     <div id="player">
       <!-- Connection to source -->
-      <audio id="stream" src="http://cadenceradio.com:8000/cadence1"></audio>
+      <audio id="stream" src="http://stream.cadenceradio.com/cadence1"></audio>
 
       <!-- Display title/artist, may add more later -->
       <div id="nowPlaying">
@@ -126,7 +126,7 @@
       <section>
         <h2>About Cadence:</h2>
         <p>Cadence is an online radio whose creation was inspired by the anime-themed <a href="http://r-a-d.io/">R/a/dio</a>.
-          Originally started as an <a href="http://cadenceradio.com/original">experiment</a> in February 2017, the project
+          Originally started as an <a href="/original/">experiment</a> in February 2017, the project
           is my first endeavour to practice a full range of IT-skills.</p>
 
           <p>Cadence's frontend is served through a Node.js webserver interacting with a Mongo music database, both configured around a Liquidsoap/Icecast stream server. </p>

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
   <meta name="msapplication-navbutton-color" content="#CCCCCC" id="ie-color">
 
   <title>Cadence Radio ♥</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Heading: Rock Salt; Subtitle: Roboto 300i; ARIA Messages: VT232; All else: PT Sans -->
   <link href="https://fonts.googleapis.com/css?family=Rock+Salt" rel="stylesheet">

--- a/public/js/aria.js
+++ b/public/js/aria.js
@@ -25,7 +25,7 @@ $(document).ready(function () {
 
     $.ajax({
       type: 'POST',
-      url: 'http://cadenceradio.com/search',
+      url: '/search',
       dataType: 'application/json',
       crossDomain: true,
       data: data,
@@ -82,11 +82,11 @@ $(document).ready(function () {
     $(".requestButton").prop('disabled', true);
 
     // Switch the request button styles so they appear red for the same amount of time
-    document.getElementById('aria-request-button').href=document.location.origin+"/css/modules/aria/request-button-disabled.css";
+    document.getElementById('aria-request-button').href="/css/modules/aria/request-button-disabled.css";
 
     $.ajax({
       type: 'POST',
-      url: 'http://cadenceradio.com/request',
+      url: '/request',
       data: data,
       success: function (result) {
         console.log(result);
@@ -94,7 +94,7 @@ $(document).ready(function () {
         // After five minutes, return functionality to the button and change to green
         setTimeout(function () {
           $(".requestButton").prop('disabled', false);
-          document.getElementById('aria-request-button').href=document.location.origin+"/css/modules/aria/request-button.css";
+          document.getElementById('aria-request-button').href="/css/modules/aria/request-button.css";
         }, 1000 * 60 * 5);
       },
       error: function (result) {
@@ -102,7 +102,7 @@ $(document).ready(function () {
         ariaSays.innerHTML = result.responseText;
         setTimeout(function () {
           $(".requestButton").prop('disabled', false);
-          document.getElementById('aria-request-button').href=document.location.origin+"/css/modules/aria/request-button.css";
+          document.getElementById('aria-request-button').href="/css/modules/aria/request-button.css";
         }, 1000 * 60 * 5);
       }
     });

--- a/public/js/radio-page.js
+++ b/public/js/radio-page.js
@@ -25,7 +25,7 @@ function defaultPlayer() {
 // GETS and displays currently playing info
 function radioTitle() {
   // Located on Testament's stream client 'web' folder
-  var url = 'http://cadenceradio.com:8000/now-playing.xsl';
+  var url = 'http://stream.cadenceradio.com/now-playing.xsl';
 
   $.ajax({
     type: 'GET',
@@ -74,7 +74,7 @@ $(document).ready(function () {
   if (stream.paused) {
     // Loads up the real stream again if mobile
     if (mobile) {
-      stream.src = "http://cadenceradio.com:8000/cadence1";
+      stream.src = "http://stream.cadenceradio.com/cadence1";
     }
     stream.load();
     stream.play();

--- a/public/js/theme-changer.js
+++ b/public/js/theme-changer.js
@@ -7,7 +7,7 @@ function setThemeColor(color) {
 // Function that starts playing the video for video themes
 function setVideo(themeObj) {
   var video = document.getElementById("video-source");
-  var filename = document.location + themeObj.videoPath;
+  var filename = document.location.origin + themeObj.videoPath;
   // Loads the video source
   if (video.src !== filename) {
     video.src = filename;

--- a/public/lofi/index.html
+++ b/public/lofi/index.html
@@ -15,7 +15,7 @@
   <meta name="msapplication-navbutton-color" content="#CCCCCC" id="ie-color">
 
   <title>Cadence LO-FI ♥</title>
-  <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+  <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 
   <!-- Heading: Rock Salt; Subtitle: Roboto 300i; ARIA Messages: VT232; All else: PT Sans -->
   <link href="https://fonts.googleapis.com/css?family=Rock+Salt" rel="stylesheet">

--- a/public/lofi/index.html
+++ b/public/lofi/index.html
@@ -24,7 +24,7 @@
   <link href="https://fonts.googleapis.com/css?family=VT323" rel="stylesheet">
 
   <!-- LOFI CSS -->
-  <link rel="stylesheet" type="text/css" href="../css/base/lofi.css">
+  <link rel="stylesheet" type="text/css" href="/css/base/lofi.css">
 
   <!-- jQuery Google CDN -->
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>


### PR DESCRIPTION
All paths in Cadence should now work properly when served either through HTTP or HTTPS, except perhaps `/original/`. I'm uncertain as to whether @kenellorando intends that to be an archival copy of how Cadence used to be or if it should be a working copy of Cadence with the old aesthetic.