### PR TITLE
Switch to music-metadata & avoid parsing files in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "latest",
     "express-rate-limit": "^2.9.0",
     "mongodb": "^2.2.31",
-    "musicmetadata": "latest",
+    "music-metadata": "latest",
     "telnet-client": "latest"
   },
   "devDependencies": {},


### PR DESCRIPTION
Related issue: #117

1. Replaced [musicmetadata](https://github.com/leetreveil/musicmetadata) dependency with [music-metadata](https://github.com/borewit/music-metadata)
2. Ensure files are processed in a serial manner, by calling `next()` in the metadata callback.
   * Related issue: Borewit/music-metadata#109

Good luck with your project!