### PR TITLE
Avoid duplicating a slash in video paths

### DIFF
--- a/public/js/theme-changer.js
+++ b/public/js/theme-changer.js
@@ -7,7 +7,7 @@ function setThemeColor(color) {
 // Function that starts playing the video for video themes
 function setVideo(themeObj) {
   var video = document.getElementById("video-source");
-  var filename = document.location + themeObj.videoPath;
+  var filename = document.origin + themeObj.videoPath;
   // Loads the video source
   if (video.src !== filename) {
     video.src = filename;


### PR DESCRIPTION
This is a bug I noticed while testing the new server.

It's not of material harm, but it is annoying and it can be a source of
bugs.