### PR TITLE
Load certain resources asynchronously

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,11 +43,11 @@
   <!-- Theme data JSON -->
   <script type="text/javascript" src="/js/theme.json"></script>
   <!-- ARIA Front-end -->
-  <script src="/js/aria.js" async></script>
+  <script src="/js/aria.js" async defer></script>
   <!-- Theme Changer -->
-  <script src="/js/theme-changer.js" async></script>
+  <script src="/js/theme-changer.js" async defer></script>
   <!-- Radio-page script -->
-  <script src="/js/radio-page.js" async></script>
+  <script src="/js/radio-page.js" async defer></script>
 </head>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -38,16 +38,29 @@
   <!-- Selected style CSS -->
   <link rel="stylesheet" type="text/css" id="selected-css" href=".">
 
-  <!-- jQuery Google CDN -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-  <!-- Theme data JSON -->
-  <script type="text/javascript" src="/js/theme.json"></script>
-  <!-- ARIA Front-end -->
-  <script src="/js/aria.js" async defer></script>
-  <!-- Theme Changer -->
-  <script src="/js/theme-changer.js" async defer></script>
-  <!-- Radio-page script -->
-  <script src="/js/radio-page.js" async defer></script>
+  <!-- Conditionally use special behavior for IE9 (only supported IE with buggy defer) -->
+  <!--[if IE]>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script type="text/javascript" src="/js/theme.json"></script>
+    <script src="/js/aria.js" async defer></script>
+    <script src="/js/theme-changer.js" async defer></script>
+    <script src="/js/radio-page.js" async defer></script>
+  <![endif]-->
+  
+  <!-- IE later than 10 and other browsers don't understand conditional comments. -->
+  <!-- These browsers guarantee the execution order of deferred scripts, so all the scripts can get defers -->
+  <!-- [if !IE]> -->
+    <!-- jQuery Google CDN -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js" defer></script>
+    <!-- Theme data JSON -->
+    <script type="text/javascript" src="/js/theme.json" defer></script>
+    <!-- ARIA Front-end -->
+    <script src="/js/aria.js" defer></script>
+    <!-- Theme Changer -->
+    <script src="/js/theme-changer.js" defer></script>
+    <!-- Radio-page script -->
+    <script src="/js/radio-page.js" defer></script>
+  <!-- <![endif] -->
 </head>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -35,11 +35,11 @@
   <!-- Theme data JSON -->
   <script type="text/javascript" src="/js/theme.json"></script>
   <!-- ARIA Front-end -->
-  <script src="/js/aria.js"></script>
+  <script src="/js/aria.js" async></script>
   <!-- Theme Changer -->
-  <script src="/js/theme-changer.js"></script>
+  <script src="/js/theme-changer.js" async></script>
   <!-- Radio-page script -->
-  <script src="/js/radio-page.js"></script>
+  <script src="/js/radio-page.js" async></script>
 </head>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -18,10 +18,11 @@
   <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
 
   <!-- Heading: Rock Salt; Subtitle: Roboto 300i; ARIA Messages: VT232; All else: PT Sans -->
-  <link href="https://fonts.googleapis.com/css?family=Rock+Salt" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300i" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=PT+Sans" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css?family=VT323" rel="stylesheet">
+  <!-- CSS preloading technique as described at https://stackoverflow.com/a/40314216 -->
+  <link href="https://fonts.googleapis.com/css?family=Rock+Salt" rel="stylesheet" media="none" onload="if(media!='all') media='all'">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300i" rel="stylesheet" media="none" onload="if(media!='all') media='all'">
+  <link href="https://fonts.googleapis.com/css?family=PT+Sans" rel="stylesheet" media="none" onload="if(media!='all') media='all'">
+  <link href="https://fonts.googleapis.com/css?family=VT323" rel="stylesheet" media="none" onload="if(media!='all') media='all'">
 
   <!-- Import base, norm, modules CSS -->
   <link rel="stylesheet" type="text/css" href="/css/master-import.css">

--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,13 @@
   <link href="https://fonts.googleapis.com/css?family=Roboto:300i" rel="stylesheet" media="none" onload="if(media!='all') media='all'">
   <link href="https://fonts.googleapis.com/css?family=PT+Sans" rel="stylesheet" media="none" onload="if(media!='all') media='all'">
   <link href="https://fonts.googleapis.com/css?family=VT323" rel="stylesheet" media="none" onload="if(media!='all') media='all'">
+  
+  <noscript id="scriptless-fonts">
+    <link href="https://fonts.googleapis.com/css?family=Rock+Salt" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300i" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=PT+Sans" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=VT323" rel="stylesheet">
+  </noscript>
 
   <!-- Import base, norm, modules CSS -->
   <link rel="stylesheet" type="text/css" href="/css/master-import.css">


### PR DESCRIPTION
Page rendering can occur more quickly if resources are loaded independently of the page itself.

Therefore, fonts and either the 'last line' of scripts (those which no other scripts on the page depend on, on IE9) or all scripts (on non-IE9 browsers) are loaded while the page is being rendered. This means that on slow connections, the page is displayed earlier.

However, on extremely slow connections, the page could load before the resources are loaded. This means that the user could briefly see Cadence without loaded fonts, and without working ARIA, radio, and theme engine.

I think this is better than the user seeing a blank page while these resources are loaded, therefore, I believe that this PR enhances the user experience on very slow connections.

As an aside, because the `defaultTheme` and `defaultPlayer` functions are fired on-load, they do wait for the async scripts to finish loading (unlike the 'ready' handlers used in the scripts themselves, which fire either when the DOM is ready or when the handler is loaded, whichever comes last), along with all other page resources. This means that the user already sees Cadence unthemed without default radio settings until everything loads - I've been noticing this a lot when loading my development copy of Cadence while the authoritative copy isn't up (which means the browser waits forever for the stream to load before loading the theme).