### PR TITLE
Update jQuery version to 3.3.1

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
 
   <!-- Conditionally use special behavior for IE9 (only supported IE with buggy defer) -->
   <!--[if IE]>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script type="text/javascript" src="/js/theme.json"></script>
     <script src="/js/aria.js" async defer></script>
     <script src="/js/theme-changer.js" async defer></script>
@@ -51,7 +51,7 @@
   <!-- These browsers guarantee the execution order of deferred scripts, so all the scripts can get defers -->
   <!-- [if !IE]> -->
     <!-- jQuery Google CDN -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js" defer></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js" defer></script>
     <!-- Theme data JSON -->
     <script type="text/javascript" src="/js/theme.json" defer></script>
     <!-- ARIA Front-end -->


### PR DESCRIPTION
Nothing important was added, but there are a few bugfixes involved.

It's also good to stay up-to-date so that we can share the cache with other websites using the most current jQuery version.