### PR TITLE
Load theme and radio player code earlier

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,7 @@
 </head>
 
 
-<body onload="defaultTheme(); defaultPlayer();">
+<body>
   <main>
     <h1 id="title">CADENCE</h1>
     <p id="subtitle">A Rhythmic Experience</p>

--- a/public/js/radio-page.js
+++ b/public/js/radio-page.js
@@ -123,4 +123,5 @@ function toggleChangelog() {
   }
 }
 
+// Execute the load handler whenever the page is ready
 $(document).ready(defaultPlayer);

--- a/public/js/radio-page.js
+++ b/public/js/radio-page.js
@@ -122,3 +122,5 @@ function toggleChangelog() {
     document.getElementById("oldToggle").innerHTML = "Hide Full History";
   }
 }
+
+$(document).ready(defaultPlayer);

--- a/public/js/theme-changer.js
+++ b/public/js/theme-changer.js
@@ -110,3 +110,5 @@ function defaultTheme() {
     themeChanger(theme);
   }
 }
+
+$(document).ready(defaultTheme);

--- a/public/js/theme-changer.js
+++ b/public/js/theme-changer.js
@@ -111,4 +111,5 @@ function defaultTheme() {
   }
 }
 
+// Execute the load handler whenever the page is ready
 $(document).ready(defaultTheme);


### PR DESCRIPTION
These are now loaded when the DOM is ready (if possible) instead of when all resources have loaded.

This makes these load in before certain resources finish downloading, which makes users perceive Cadence as loading in faster.

I'm stepping on @JakobFrank's toes a bit here since I've considered this part of #60 for a while despite wanting to do it, but honestly, this has been pissing me off a lot. Since the Cadence stream server is down, my development has been showing the theme not loading, which makes the page look incomplete.

Therefore, here's the PR to fix this problem, and hopefully boost the quality-of-life for real users a little while we're at it.