### PR TITLE
Better short screen overlap fix

### DIFF
--- a/public/css/base/base.css
+++ b/public/css/base/base.css
@@ -385,3 +385,10 @@ a:active {
     padding-right: 12em;
   }
 }
+
+/* Fix for #aria overlapping main on short screens - Make sure main takes as much room in the flow as on the screen. */
+@media (max-height: 550px) {
+  main {
+    height: auto;
+  }
+}

--- a/public/css/master-import.css
+++ b/public/css/master-import.css
@@ -11,4 +11,3 @@
 @import url(modules/volume-bar.css);
 @import url(modules/theme-dropdown.css);
 @import url(modules/aria/aria.css);
-@import url(modules/shortscreen-fix.css);

--- a/public/css/modules/shortscreen-fix.css
+++ b/public/css/modules/shortscreen-fix.css
@@ -2,13 +2,6 @@
 
 @media (max-height: 550px) {
   main {
-    width: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
-
-  #aria {
-    margin-top: 550px;
+    height: auto;
   }
 }

--- a/public/css/modules/shortscreen-fix.css
+++ b/public/css/modules/shortscreen-fix.css
@@ -1,7 +1,0 @@
-/* File to group together layout changes made to fix short screen overlaps */
-
-@media (max-height: 550px) {
-  main {
-    height: auto;
-  }
-}


### PR DESCRIPTION
This fix should be roughly functionally equivalent to the one in #145, but shouldn't experience the same UI glitches.

Unfortunately, I didn't remember that there was a clean, easy, and dumb solution before I wrote the clever one. And @kenellorando, for once (see #40), merged a pull request early, before I wrote this fix.

...sorry, @kenellorando.