### PR TITLE
Loop all given file extensions

### DIFF
--- a/server/database.go
+++ b/server/database.go
@@ -136,7 +136,7 @@ func databasePopulate() error {
 		}
 
 		// Skip non-music files
-		var extensions = [...]string{".mp3", ".ogg", ".flac"}
+		var extensions = [...]string{".mp3", ".ogg", ".flac", ".m4a"}
 		for _, ext := range extensions {
 			if strings.HasSuffix(path, ext) {
 				// Open a file for reading
@@ -167,6 +167,7 @@ func databasePopulate() error {
 				continue
 			}
 		}
+		return nil
 	})
 
 	// Marshal the new JSON data and store it on file

--- a/server/database.go
+++ b/server/database.go
@@ -163,8 +163,9 @@ func databasePopulate() error {
 
 				// Close the file
 				file.Close()
+				return nil
 			} else {
-				continue
+				return nil
 			}
 		}
 		return nil

--- a/server/database.go
+++ b/server/database.go
@@ -139,37 +139,34 @@ func databasePopulate() error {
 		var extensions = [...]string{".mp3", ".ogg", ".flac"}
 		for _, ext := range extensions {
 			if strings.HasSuffix(path, ext) {
-				break
+				// Open a file for reading
+				file, e := os.Open(path)
+				if e != nil {
+					return e
+				}
+
+				// Read metadata from the file
+				tags, er := tag.ReadFrom(file)
+				if er != nil {
+					return er
+				}
+
+				// Insert into database
+				_, err = database.Exec(insertInto, tags.Title(), tags.Album(), tags.Artist(),
+					tags.Genre(), tags.Year(), path)
+				if err != nil {
+					panic(err)
+				}
+
+				// Add song (as LibraryEntry) to full libraryData
+				libraryData = append(libraryData, LibraryEntry{Artist: tags.Artist(), Title: tags.Title()})
+
+				// Close the file
+				file.Close()
 			} else {
-				return nil
+				continue
 			}
 		}
-
-		// Open a file for reading
-		file, e := os.Open(path)
-		if e != nil {
-			return e
-		}
-
-		// Read metadata from the file
-		tags, er := tag.ReadFrom(file)
-		if er != nil {
-			return er
-		}
-
-		// Insert into database
-		_, err = database.Exec(insertInto, tags.Title(), tags.Album(), tags.Artist(),
-			tags.Genre(), tags.Year(), path)
-		if err != nil {
-			panic(err)
-		}
-
-		// Add song (as LibraryEntry) to full libraryData
-		libraryData = append(libraryData, LibraryEntry{Artist: tags.Artist(), Title: tags.Title()})
-
-		// Close the file
-		file.Close()
-		return nil
 	})
 
 	// Marshal the new JSON data and store it on file


### PR DESCRIPTION
This PR moves the database population code around a bit so that the extension check will now check _all_ listed file types rather than just the first one. 