### PR TITLE
Display warning on Safari browser or mobile Apple device

### DIFF
--- a/public/js/player.js
+++ b/public/js/player.js
@@ -91,9 +91,10 @@ $(document).ready(function () {
 
 // Display page warning on iOS or Safari devices
 $(document).ready(function () {
-    let appleUA = /iOS|Safari/i.test(navigator.userAgent);
+    let safariUA = /Apple/i.test(navigator.vendor);
+    let iOSUA = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
-    if (appleUA) {
+    if (iOSUA || safariUA) {
         alert("You appear to be using an iOS device or a Safari browser. Cadence stream playback may not be compatible with your platform.")
     }
 });

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -74,7 +74,7 @@ $(document).ready(function () {
 });
 
 
-// Toggle the stream with the playButton
+// Get latest source release title
 $(document).ready(function () {
     $.ajax({
         type: 'GET',
@@ -87,6 +87,15 @@ $(document).ready(function () {
             document.getElementById("release").innerHTML = "Could not retrieve version data.";
         }
     });
+});
+
+// Display page warning on iOS or Safari devices
+$(document).ready(function () {
+    let appleUA = /iOS|Safari/i.test(navigator.userAgent);
+
+    if (appleUA) {
+        alert("You appear to be using an iOS device or a Safari browser. Cadence stream playback may not be compatible with your platform.")
+    }
 });
 
 // Volume control


### PR DESCRIPTION
This PR adds a warning about stream playback if the client is visiting with a Safari browser or mobile Apple device (iPhone / iPad / iPod). This implements #177.