### PR TITLE
4.2.3 UI Upgrade

### DIFF
--- a/public/css/base.css
+++ b/public/css/base.css
@@ -31,8 +31,8 @@ body {
     font-family: 'Roboto Condensed', sans-serif;
     background-color: whitesmoke;
 
-    background-color: #282726;
-    color: beige;
+    background-color: #1e2020;
+    color:#e2e9cc;
 }
 main {
     background-color: inherit;
@@ -43,13 +43,13 @@ main {
 
 a {
     cursor: pointer;
-    color: orangered;
+    color: #d37d5b;
     text-decoration: none;
 }
 
 /* Navigation */
 nav {
-    background-color: #1a1a1d;
+    background-color:#151616;
 
     font-weight: 300;
 
@@ -111,8 +111,8 @@ img {
     font-size: 27px;
 }
 #player #playButton {
-    background-color: #DBEFEE;
-    color: #454555;
+    background-color: #263635;
+    color: #dddad4;
     
     font-size: 20px;
     text-align: center;
@@ -240,7 +240,7 @@ input[type=range] {
     width: 200px;
     border: none;
 
-    background-color: beige;
+    background-color: #313535;
 }
   
 input[type=range]:focus {
@@ -257,11 +257,11 @@ input[type=range]::-webkit-slider-runnable-track {
 }
 
 input[type=range]::-webkit-slider-thumb {
-    border: 2px solid beige;
+    border: 2px solid #dddad4;
     height: 13px;
     width: 13px;
     border-radius: 50px;
-    background: rgb(98, 39, 138);
+    background: rgb(95, 84, 105);
     cursor: pointer;
     -webkit-appearance: none;
 
@@ -289,19 +289,18 @@ input[type=range]::-webkit-slider-thumb {
 
 @media (min-width: 850px) {
     main {
-        padding-left: 15%;
-        padding-right: 15%;
+        padding-left: 8%;
+        padding-right: 8%;
     }
     nav {
-        padding-left: 15%;
-        padding-right: 15%;
+        padding-left: 4%;
+        padding-right: 4%;
     }
     #frontMain {
         column-count: 2;
         column-gap: 70px;
     }
     nav #navLeft {
-        padding-top: 0px;
         display: inline-block;
         text-align: left;
     }
@@ -324,22 +323,47 @@ input[type=range]::-webkit-slider-thumb {
 
 @media (min-width: 1200px) {
     main {
-        padding-left: 20%;
-        padding-right: 20%;
+        padding-left: 16%;
+        padding-right: 16%;
     }
     nav {
-        padding-left: 20%;
-        padding-right: 20%;
+        padding-left: 11%;
+        padding-right: 11%;
+        height: 100%;
+    }
+    #navLeft a {
+        font-size: 24px
+    }
+    #navRight a {
+        font-size: 18px;
+    }
+    #player {
+        transform: scale(1.02);
     }
 }
 
 @media (min-width: 1920px) {
     main {
-        padding-left: 25%;
-        padding-right: 25%;
+        padding-left: 26%;
+        padding-right: 26%;
+        font-size: 18px;
     }
     nav {
-        padding-left: 25%;
-        padding-right: 25%;
+        padding-left: 21%;
+        padding-right: 21%;
+    }
+    #player {
+        transform: scale(1.05);
+    }
+}
+
+@media (min-width: 2400px) {
+    main {
+        padding-left: 32%;
+        padding-right: 32%;
+    }
+    nav {
+        padding-left: 27%;
+        padding-right: 27%;
     }
 }

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -87,7 +87,6 @@ nav #tabMain {
     font-family: 'Rock Salt', cursive;
     font-size: 26px;
 }
-
 img {
     max-width: 100%;
 }
@@ -217,11 +216,11 @@ img {
     margin-bottom: 25px;
 }
 
-#frontThemes {
+#frontTheme {
     display: none;
 }
 
-#frontThemes .themeButton {
+#frontTheme .themeButton {
     font-family: 'Inconsolata', monospace;
     font-size: 16px;
     text-decoration: none;

--- a/public/css/base.css
+++ b/public/css/base.css
@@ -77,10 +77,11 @@ nav #navRight {
     font-family: 'Roboto Condensed', sans-serif;
     padding-top: 4px;
     padding-bottom: 10px;
+    white-space: nowrap;
 }
 nav #navRight a {
-    margin-left: 15px;
-    margin-right: 15px;
+    margin-left: 14px;
+    margin-right: 14px;
 }
 nav #tabMain {
     font-family: 'Rock Salt', cursive;
@@ -139,6 +140,10 @@ img {
 
 
 #frontRequest {
+    display: block;
+}
+
+#frontAbout {
     display: none;
 }
 
@@ -295,10 +300,6 @@ input[type=range]::-webkit-slider-thumb {
     nav {
         padding-left: 4%;
         padding-right: 4%;
-    }
-    #frontMain {
-        column-count: 2;
-        column-gap: 70px;
     }
     nav #navLeft {
         display: inline-block;

--- a/public/css/modules/themeButton.css
+++ b/public/css/modules/themeButton.css
@@ -1,8 +1,8 @@
-#frontThemes .activeTheme {
-    color: rgb(103, 211, 100);
-    background-color: rgb(43, 43, 38);
+#frontTheme .activeTheme {
+    color: rgb(81, 194, 132);
+    background-color: rgb(51, 51, 45);
 }
 
-#frontThemes .inactiveTheme {
-    color: rgb(96, 175, 221);
+#frontTheme .inactiveTheme {
+    color: rgb(129, 160, 179);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -89,7 +89,7 @@
                 <a class="twitter-timeline" data-lang="en" data-width="500" data-height="300" data-theme="dark" data-link-color="#19CF86" href="https://twitter.com/CadenceRadio?ref_src=twsrc%5Etfw">Tweets by CadenceRadio</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
 
-            <div id="frontThemes">
+            <div id="frontTheme">
                 <div class="column">
                     <h2>Themes</h2>
                     <button type="button" class="themeButton" id="Default">Default</button>

--- a/public/index.html
+++ b/public/index.html
@@ -34,8 +34,9 @@
             </span>
             <span id="navRight">
                 <a id="tabRequest">Request</a>
+                <a id="tabAbout">About</a>
                 <a id="tabTheme">Theme</a>
-                <a href="https://github.com/kenellorando/cadence" target="_blank">Source</a>
+                <a href="https://github.com/kenellorando/cadence" target="_blank">(➜ Github)</a>
             </span>
         </nav>
         <main>
@@ -59,20 +60,6 @@
 
             <hr/>
 
-            <div id="frontMain">
-                <div class="column">
-                    <h2>About Cadence</h2>
-                    <p>Cadence is an online radio with a heavy focus on anime and Asian music.</p>
-                    <p>This project was originally started in February 2017 as my first endeavour to practice a full range of tech skills, from development to server administration. The current iteration (4.x) of Cadence is written in Go without any frameworks. Cadence provides users with the ability to search the library as well as make song requests.</p>
-                    <p>Active development continues to this day. All source is available on <a href="https://github.com/kenellorando/cadence">GitHub</a>.</p>
-                    <p><b>Cadence Radio is a DMCA compliant, "non-commercial educational" (NCE) broadcast. As an NCE, Cadence Radio is non-profit and does not accept advertisements for its webpages or broadcasts.</b></p>
-                </div>
-                <div class="column">
-                    <h2>Announcements</h2>
-                    <a class="twitter-timeline" data-lang="en" data-width="500" data-height="300" data-theme="dark" data-link-color="#19CF86" href="https://twitter.com/CadenceRadio?ref_src=twsrc%5Etfw">Tweets by CadenceRadio</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-                </div>
-            </div>
-
             <div id="frontRequest">
                 <div class="column">
                     <h2>Request</h2>
@@ -90,6 +77,16 @@
                     <p>Retrieve a listing of all songs in the Cadence rotation, to help you better find what songs are available for request.</p>
                     <div id="library"><a id="getLibrary">Load Song Library</a></div>
                 </div>
+            </div>
+
+            <div id="frontAbout">
+                <h2>About Cadence</h2>
+                <p>Cadence is an online radio with a heavy focus on anime and Asian music.</p>
+                <p>This project was originally started in February 2017 as my first endeavour to practice a full range of tech skills, from development to server administration. The current iteration (4.x) of Cadence is written in Go without any frameworks. Cadence provides users with the ability to search the library as well as make song requests.</p>
+                <p>Active development continues to this day. All source is available on <a href="https://github.com/kenellorando/cadence">GitHub</a>.</p>
+                <p><b>Cadence Radio is a DMCA compliant, "non-commercial educational" (NCE) broadcast. As an NCE, Cadence Radio is non-profit and does not accept advertisements for its webpages or broadcasts.</b></p>
+
+                <a class="twitter-timeline" data-lang="en" data-width="500" data-height="300" data-theme="dark" data-link-color="#19CF86" href="https://twitter.com/CadenceRadio?ref_src=twsrc%5Etfw">Tweets by CadenceRadio</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
 
             <div id="frontThemes">

--- a/public/index.html
+++ b/public/index.html
@@ -85,7 +85,8 @@
                 <p>This project was originally started in February 2017 as my first endeavour to practice a full range of tech skills, from development to server administration. The current iteration (4.x) of Cadence is written in Go without any frameworks. Cadence provides users with the ability to search the library as well as make song requests.</p>
                 <p>Active development continues to this day. All source is available on <a href="https://github.com/kenellorando/cadence">GitHub</a>.</p>
                 <p><b>Cadence Radio is a DMCA compliant, "non-commercial educational" (NCE) broadcast. As an NCE, Cadence Radio is non-profit and does not accept advertisements for its webpages or broadcasts.</b></p>
-
+                <hr/>
+                <h2>Updates</h2>
                 <a class="twitter-timeline" data-lang="en" data-width="500" data-height="300" data-theme="dark" data-link-color="#19CF86" href="https://twitter.com/CadenceRadio?ref_src=twsrc%5Etfw">Tweets by CadenceRadio</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
             </div>
 

--- a/public/js/tabs.js
+++ b/public/js/tabs.js
@@ -1,19 +1,19 @@
 // Switch the display of the front matter
 $(document).ready(function () {
-    document.getElementById("tabMain").addEventListener('click', function(){
-        document.getElementById("frontMain").style.display = "block";
-        document.getElementById("frontRequest").style.display = "none";
-        document.getElementById("frontThemes").style.display = "none";
-    }, true);
-
     document.getElementById("tabRequest").addEventListener('click', function(){
-        document.getElementById("frontMain").style.display = "none";
+        document.getElementById("frontAbout").style.display = "none";
         document.getElementById("frontRequest").style.display = "block";
         document.getElementById("frontThemes").style.display = "none";
     }, true);
 
+    document.getElementById("tabAbout").addEventListener('click', function(){
+        document.getElementById("frontAbout").style.display = "block";
+        document.getElementById("frontRequest").style.display = "none";
+        document.getElementById("frontThemes").style.display = "none";
+    }, true);
+
     document.getElementById("tabTheme").addEventListener('click', function(){
-        document.getElementById("frontMain").style.display = "none";
+        document.getElementById("frontAbout").style.display = "none";
         document.getElementById("frontRequest").style.display = "none";
         document.getElementById("frontThemes").style.display = "block";
     }, true);

--- a/public/js/tabs.js
+++ b/public/js/tabs.js
@@ -1,20 +1,29 @@
 // Switch the display of the front matter
 $(document).ready(function () {
     document.getElementById("tabRequest").addEventListener('click', function(){
-        document.getElementById("frontAbout").style.display = "none";
-        document.getElementById("frontRequest").style.display = "block";
-        document.getElementById("frontThemes").style.display = "none";
+        replace("Request")
     }, true);
 
     document.getElementById("tabAbout").addEventListener('click', function(){
-        document.getElementById("frontAbout").style.display = "block";
-        document.getElementById("frontRequest").style.display = "none";
-        document.getElementById("frontThemes").style.display = "none";
+        replace("About")
     }, true);
 
     document.getElementById("tabTheme").addEventListener('click', function(){
-        document.getElementById("frontAbout").style.display = "none";
-        document.getElementById("frontRequest").style.display = "none";
-        document.getElementById("frontThemes").style.display = "block";
+        replace("Theme")
     }, true);
+
+    document.getElementById("tabRequest").style.fontWeight = "600";
 });
+
+function replace(target) {
+    keys = [ "About", "Request", "Theme" ]
+    for (key of keys) {
+        if (key == target) {
+            document.getElementById("front" + key).style.display = "block";
+            document.getElementById("tab" + key).style.fontWeight = "600";
+        } else {
+            document.getElementById("front" + key).style.display = "none";
+            document.getElementById("tab" + key).style.fontWeight = "300";
+        }
+    }
+}


### PR DESCRIPTION
PR makes a relatively significant number of changes to the site's base UI. Summary: this provides support for wider screen widths, makes a base visual color update, and provides users better visual interactive feedback as they interact with the page.

- Base media queries are updated to support ultra-wide widths (up to a UHD 4k screen). At larger widths, main padding is used more liberally and the navbar padding is reduced. At ultra-wide widths, all text is upsized so it fills more of the screen. 
- The base color scheme is updated to be less bright and have less contrast than before. (#180)
- The 'About' block is replaced by the 'Request' block as default. 
- The navigation bar is updated so 'About' has its own button, rather than being hidden in the title header. 
- The 'About' block is now single-column at all widths rather than double. About subsections are now split with an `<hr/>`.
- The 'Source' button is changed to 'Github' with an arrow, signaling that the link navigates off-page.
- Block navbar tabs are bolded when they are active on the screen.


Visual at the widest supported width:
<details>
  <summary>Before</summary>
<img width="1919" alt="Ultrawide-before" src="https://user-images.githubusercontent.com/17265041/100486953-5d36bb00-30d4-11eb-97ab-73c128876ee6.PNG">
</details>
<details>
  <summary>After</summary>
<img width="1920" alt="Ultrawide-after" src="https://user-images.githubusercontent.com/17265041/100487110-ff56a300-30d4-11eb-9aef-a9c2657a1063.PNG">
</details>