### PR TITLE
Whitelist Access Tokens through Rate Limiter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 library.json
 node_modules/
+whitelist.txt

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -70,7 +70,7 @@ SetEnvVar "CSERVER_DB_SSLMODE" "disable"
 SetEnvVar "CSERVER_DB_DRIVER" "postgres"
 SetEnvVar "CSERVER_DB_USER" "postgres"
 SetEnvVar "CSERVER_DB_TABLE" "aria"
-SetEnvVar "CSERVER_WHITELIST_DIR" "/home/cadence/cadence/"
+SetEnvVar "CSERVER_WHITELIST_PATH" "/home/cadence/cadence/whitelist.txt"
 # List of environment variables with no defaults.
 # Does not necessarily need to be used with SetSecretEnvVar(),
 # though most envvars here would make sense to hide the input.
@@ -78,7 +78,7 @@ SetSecretEnvVar "CSERVER_DB_PASS"
 
 ##############################################################
 
-touch $CSERVER_WHITELIST_PATH + "whitelist.txt"
-chmod 755 $CSERVER_WHITELIST_PATH + "whitelist.txt"
+touch $CSERVER_WHITELIST_PATH
+chmod 755 $CSERVER_WHITELIST_PATH
 
 echo -e "\nSETUP.sh completed."

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -70,11 +70,15 @@ SetEnvVar "CSERVER_DB_SSLMODE" "disable"
 SetEnvVar "CSERVER_DB_DRIVER" "postgres"
 SetEnvVar "CSERVER_DB_USER" "postgres"
 SetEnvVar "CSERVER_DB_TABLE" "aria"
+SetEnvVar "CSERVER_WHITELIST_DIR" "/home/cadence/cadence/"
 # List of environment variables with no defaults.
 # Does not necessarily need to be used with SetSecretEnvVar(),
 # though most envvars here would make sense to hide the input.
 SetSecretEnvVar "CSERVER_DB_PASS"
 
 ##############################################################
+
+touch $CSERVER_WHITELIST_PATH + "whitelist.txt"
+chmod 755 $CSERVER_WHITELIST_PATH + "whitelist.txt"
 
 echo -e "\nSETUP.sh completed."

--- a/server/main.go
+++ b/server/main.go
@@ -123,10 +123,14 @@ func main() {
 		s.PathPrefix("/").Handler(http.FileServer(http.Dir("./public/docs"))).Methods("GET")
 	*/
 
-	// List API routes firstther specific routes next
+	// List API routes first
 	r.HandleFunc("/api/aria1/search", ARIA1Search).Methods("POST")
 	r.HandleFunc("/api/aria1/request", ARIA1Request).Methods("POST")
 	r.HandleFunc("/api/aria1/library", ARIA1Library).Methods("GET")
+
+	// Aria2
+	r.HandleFunc("/api/aria2/request", ARIA2Request).Methods("POST")
+
 	// Serve other specific routes next
 	r.HandleFunc("/", ServeRoot).Methods("GET")
 	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./public/static/"))))

--- a/server/main.go
+++ b/server/main.go
@@ -30,6 +30,7 @@ type ServerConfig struct {
 	Port          string
 	MusicDir      string
 	SourceAddress string
+	WhitelistPath string
 }
 
 // DBConfig - Database server configuration
@@ -66,6 +67,7 @@ func init() {
 	server.Port = os.Getenv("CSERVER_PORT")
 	server.MusicDir = os.Getenv("CSERVER_MUSIC_DIR")
 	server.SourceAddress = os.Getenv("CSERVER_SOURCEADDRESS")
+	server.WhitelistPath = os.Getenv("CSERVER_WHITELIST_PATH")
 	// Database server configuration
 	db.Host = os.Getenv("CSERVER_DB_HOST")
 	db.Port = os.Getenv("CSERVER_DB_PORT")

--- a/server/routes.go
+++ b/server/routes.go
@@ -346,7 +346,7 @@ func ARIA2Check(token string) bool {
 		return false
 	}
 
-	b, err := ioutil.ReadFile(c.server.WhitelistPath + "whitelist.txt")
+	b, err := ioutil.ReadFile(c.server.WhitelistPath)
 	if err != nil {
 		panic(err)
 		return false

--- a/server/routes.go
+++ b/server/routes.go
@@ -342,7 +342,11 @@ func ARIA1Library(w http.ResponseWriter, r *http.Request) {
 func ARIA2Check(token string) bool {
 	clog.Info("ARIA2Check", fmt.Sprintf("Checking token %s", token))
 
-	b, err := ioutil.ReadFile("../whitelist.txt")
+	if len(token) != 26 {
+		return false
+	}
+
+	b, err := ioutil.ReadFile(c.server.WhitelistPath + "whitelist.txt")
 	if err != nil {
 		panic(err)
 		return false
@@ -407,8 +411,8 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Perform a check on the token
-	tokenValid := false
-	if request.Token !== "" {
+	var tokenValid bool
+	if request.Token != "" {
 		tokenValid = ARIA2Check(request.Token)
 	}
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -398,7 +398,7 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 	}
 	err = json.Unmarshal(body, &request)
 	if err != nil {
-		clog.Error("ARIA1Request", fmt.Sprintf("Failed to unmarshal http-request body from %s.", r.Header.Get("X-Forwarded-For")), err)
+		clog.Error("ARIA2Request", fmt.Sprintf("Failed to unmarshal http-request body from %s.", r.Header.Get("X-Forwarded-For")), err)
 
 		timeRemaining := 0
 		message := fmt.Sprintf("Request not completed. Request-body is possibly malformed.")
@@ -425,7 +425,7 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 		if _, ok := requestTimeoutIPs[requesterIP]; ok {
 			// If the existing IP was recently logged, deny the request.
 			if requestTimeoutIPs[requesterIP] > int(time.Now().Unix())-180 {
-				clog.Info("ARIA1Request", fmt.Sprintf("Request denied by rate limit for client %s.", r.Header.Get("X-Forwarded-For")))
+				clog.Info("ARIA2Request", fmt.Sprintf("Request denied by rate limit for client %s.", r.Header.Get("X-Forwarded-For")))
 
 				timeRemaining := requestTimeoutIPs[requesterIP] + 180 - int(time.Now().Unix())
 				message := fmt.Sprintf("Request denied. Client is rate-limited for %v seconds.", timeRemaining)
@@ -449,7 +449,7 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 	selectStatement := fmt.Sprintf("SELECT \"path\" FROM %s WHERE id=%v;", c.schema.Table, request.ID)
 	rows, err := database.Query(selectStatement)
 	if err != nil {
-		clog.Error("ARIA1Request", "Database select failed.", err)
+		clog.Error("ARIA2Request", "Database select failed.", err)
 		timeRemaining := 0
 		message := fmt.Sprintf("Request not completed. Encountered a database error.")
 
@@ -468,7 +468,7 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 	for rows.Next() {
 		err := rows.Scan(&path)
 		if err != nil {
-			clog.Error("ARIA1Request", "Data scan failed.", err)
+			clog.Error("ARIA2Request", "Data scan failed.", err)
 			timeRemaining := 0
 			message := fmt.Sprintf("Request not completed. Encountered a database error.")
 
@@ -482,13 +482,13 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	clog.Debug("ARIA1Request", fmt.Sprintf("Translated ID %v to path: %s", request.ID, path))
+	clog.Debug("ARIA2Request", fmt.Sprintf("Translated ID %v to path: %s", request.ID, path))
 
 	// Telnet to liquidsoap
-	clog.Debug("ARIA1Request", "Connecting to liquidsoap service...")
+	clog.Debug("ARIA2Request", "Connecting to liquidsoap service...")
 	conn, err := net.Dial("tcp", c.server.SourceAddress)
 	if err != nil {
-		clog.Error("ARIA1Request", "Failed to connect to audio source server.", err)
+		clog.Error("ARIA2Request", "Failed to connect to audio source server.", err)
 
 		timeRemaining := 0
 		message := fmt.Sprintf("Request not completed. Could not submit request to stream source service.")
@@ -507,7 +507,7 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(conn, "request.push "+path+"\n")
 	// Listen for reply
 	sourceServiceResponse, _ := bufio.NewReader(conn).ReadString('\n')
-	clog.Debug("ARIA1Request", fmt.Sprintf("Message from audio source server: %s", sourceServiceResponse))
+	clog.Debug("ARIA2Request", fmt.Sprintf("Message from audio source server: %s", sourceServiceResponse))
 
 	// Disconnect from liquidsoap
 	conn.Close()

--- a/server/routes.go
+++ b/server/routes.go
@@ -339,7 +339,7 @@ func ARIA1Library(w http.ResponseWriter, r *http.Request) {
 // Aria2 ////////////////////
 
 // API Token Checker -- gatekeeps unlimited requests
-func ARIA2Check(token String) bool {
+func ARIA2Check(token string) bool {
 	clog.Info("ARIA2Check", fmt.Sprintf("Checking token %s", token))
 
 	b, err := ioutil.ReadFile("../whitelist.txt")
@@ -408,8 +408,8 @@ func ARIA2Request(w http.ResponseWriter, r *http.Request) {
 
 	// Perform a check on the token
 	tokenValid := false
-	if request.Token != nil {
-		tokenValid = Aria2Check(request.Token)
+	if request.Token !== "" {
+		tokenValid = ARIA2Check(request.Token)
 	}
 
 	if tokenValid == true {

--- a/server/routes.go
+++ b/server/routes.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kenellorando/clog"
@@ -177,6 +178,7 @@ func ARIA1Request(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If the IP is in the timeout log
+
 	if _, ok := requestTimeoutIPs[requesterIP]; ok {
 		// If the existing IP was recently logged, deny the request.
 		if requestTimeoutIPs[requesterIP] > int(time.Now().Unix())-180 {
@@ -332,4 +334,190 @@ func ARIA1Library(w http.ResponseWriter, r *http.Request) {
 	jsonMarshal, _ := json.Marshal(rawJSON)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(jsonMarshal)
+}
+
+// Aria2 ////////////////////
+
+// API Token Checker -- gatekeeps unlimited requests
+func ARIA2Check(token String) bool {
+	clog.Info("ARIA2Check", fmt.Sprintf("Checking token %s", token))
+
+	b, err := ioutil.ReadFile("../whitelist.txt")
+	if err != nil {
+		panic(err)
+		return false
+	}
+	s := string(b)
+
+	if strings.Contains(s, token) {
+		return true
+	}
+	return false
+}
+
+func ARIA2Request(w http.ResponseWriter, r *http.Request) {
+	clog.Debug("ARIA2Request", fmt.Sprintf("Decoding http-request data from client %s.", r.Header.Get("X-Forwarded-For")))
+	requesterIP := r.Header.Get("X-Forwarded-For")
+
+	// Declare object for a song
+	type RequestResponse struct {
+		Message       string
+		TimeRemaining int
+	}
+
+	// Declare object to hold r body data
+	type Request struct {
+		ID    string `json:"ID"`
+		Token string `json:"Token"`
+	}
+	var request Request
+
+	// Decode json object
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		clog.Error("ARIA1Request", fmt.Sprintf("Failed to read http-request body from %s.", r.Header.Get("X-Forwarded-For")), err)
+
+		timeRemaining := 0
+		message := fmt.Sprintf("Request not completed. Request-body is possibly malformed.")
+
+		// Return data to client
+		requestResponse := RequestResponse{message, timeRemaining}
+		jsonMarshal, _ := json.Marshal(requestResponse)
+
+		w.WriteHeader(http.StatusBadRequest) // 400 Bad Request
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonMarshal)
+		return
+	}
+	err = json.Unmarshal(body, &request)
+	if err != nil {
+		clog.Error("ARIA1Request", fmt.Sprintf("Failed to unmarshal http-request body from %s.", r.Header.Get("X-Forwarded-For")), err)
+
+		timeRemaining := 0
+		message := fmt.Sprintf("Request not completed. Request-body is possibly malformed.")
+
+		// Return data to client
+		requestResponse := RequestResponse{message, timeRemaining}
+		jsonMarshal, _ := json.Marshal(requestResponse)
+
+		w.WriteHeader(http.StatusBadRequest) // 400 Bad Request
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonMarshal)
+		return
+	}
+
+	// Perform a check on the token
+	tokenValid := false
+	if request.Token != nil {
+		tokenValid = Aria2Check(request.Token)
+	}
+
+	if tokenValid == true {
+		clog.Info("ARIA2Request", fmt.Sprintf("Client %s using valid token to bypass timeout.", r.Header.Get("X-Forwarded-For")))
+	} else { // Perform check on timeout log in memory
+		if _, ok := requestTimeoutIPs[requesterIP]; ok {
+			// If the existing IP was recently logged, deny the request.
+			if requestTimeoutIPs[requesterIP] > int(time.Now().Unix())-180 {
+				clog.Info("ARIA1Request", fmt.Sprintf("Request denied by rate limit for client %s.", r.Header.Get("X-Forwarded-For")))
+
+				timeRemaining := requestTimeoutIPs[requesterIP] + 180 - int(time.Now().Unix())
+				message := fmt.Sprintf("Request denied. Client is rate-limited for %v seconds.", timeRemaining)
+
+				// Return data to client
+				requestResponse := RequestResponse{message, timeRemaining}
+				jsonMarshal, _ := json.Marshal(requestResponse)
+
+				w.WriteHeader(http.StatusTooManyRequests) // 429 Too Many Requests
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", strconv.Itoa(timeRemaining))
+				w.Write(jsonMarshal)
+				return
+			}
+		}
+	}
+
+	clog.Debug("ARIA2Request", fmt.Sprintf("Received a song request for song ID #%v.", request.ID))
+	clog.Debug("ARIA2Request", "Searching database for corresponding path...")
+
+	selectStatement := fmt.Sprintf("SELECT \"path\" FROM %s WHERE id=%v;", c.schema.Table, request.ID)
+	rows, err := database.Query(selectStatement)
+	if err != nil {
+		clog.Error("ARIA1Request", "Database select failed.", err)
+		timeRemaining := 0
+		message := fmt.Sprintf("Request not completed. Encountered a database error.")
+
+		// Return data to client
+		requestResponse := RequestResponse{message, timeRemaining}
+		jsonMarshal, _ := json.Marshal(requestResponse)
+
+		w.WriteHeader(http.StatusInternalServerError) // 500 Server Error
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonMarshal)
+		return
+	}
+
+	// "Every call to Scan, even the first one, must be preceded by a call to Next."
+	var path string
+	for rows.Next() {
+		err := rows.Scan(&path)
+		if err != nil {
+			clog.Error("ARIA1Request", "Data scan failed.", err)
+			timeRemaining := 0
+			message := fmt.Sprintf("Request not completed. Encountered a database error.")
+
+			// Return data to client
+			requestResponse := RequestResponse{message, timeRemaining}
+			jsonMarshal, _ := json.Marshal(requestResponse)
+
+			w.WriteHeader(http.StatusInternalServerError) // 500 Server Error
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(jsonMarshal)
+			return
+		}
+	}
+	clog.Debug("ARIA1Request", fmt.Sprintf("Translated ID %v to path: %s", request.ID, path))
+
+	// Telnet to liquidsoap
+	clog.Debug("ARIA1Request", "Connecting to liquidsoap service...")
+	conn, err := net.Dial("tcp", c.server.SourceAddress)
+	if err != nil {
+		clog.Error("ARIA1Request", "Failed to connect to audio source server.", err)
+
+		timeRemaining := 0
+		message := fmt.Sprintf("Request not completed. Could not submit request to stream source service.")
+
+		// Return data to client
+		requestResponse := RequestResponse{message, timeRemaining}
+		jsonMarshal, _ := json.Marshal(requestResponse)
+
+		w.WriteHeader(http.StatusServiceUnavailable) // 503 Server Error
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jsonMarshal)
+		return
+	}
+
+	// Push request over connection
+	fmt.Fprintf(conn, "request.push "+path+"\n")
+	// Listen for reply
+	sourceServiceResponse, _ := bufio.NewReader(conn).ReadString('\n')
+	clog.Debug("ARIA1Request", fmt.Sprintf("Message from audio source server: %s", sourceServiceResponse))
+
+	// Disconnect from liquidsoap
+	conn.Close()
+
+	// Create or overwrite existing log times if time and request body look OK
+	requestTimeoutIPs[requesterIP] = int(time.Now().Unix())
+
+	// Return 202 OK to client
+	timeRemaining := requestTimeoutIPs[requesterIP] + 180 - int(time.Now().Unix())
+	message := fmt.Sprintf("Request accepted!")
+
+	// Return data to client
+	requestResponse := RequestResponse{message, timeRemaining}
+	jsonMarshal, _ := json.Marshal(requestResponse)
+
+	w.WriteHeader(http.StatusAccepted) // 202 Accepted
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonMarshal)
+	return
 }


### PR DESCRIPTION
PR creates a new API route `/api/aria2/request`, which implements rate-limit bypassing by API token. It takes raw JSON body data as follows, where `ID` is a song's identifier number and `Token` is a unique twenty-six character API string, provided by me:
```
{
  "ID": "<number>" // Required
  "Token": "<API Token>" // Required only for limit bypassing
}
```

For applications which would like to bypass the rate limiter, please request an API key and redirect your application's request routes to https://cadenceradio.com/api/aria2/request

Addresses #175 