### PR TITLE
Fix continuous/non-continuous background load functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -42,7 +42,7 @@
         <main>
             <div id="player">
                 <!-- Connection to source -->
-                <audio id="stream" src="https://stream.cadenceradio.com/cadence1" type="audio/mp3"></audio>
+                <audio id="stream" src="" type="audio/mp3"></audio>
                 <!-- Now playing information -->
                 <div id="status">Disconnected from server.</div>
 

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -59,7 +59,6 @@ $(document).ready(function () {
                 stream.src = "";
             }
             stream.load();
-            stream.pause();
             // Replace the ► in the button when paused
             document.getElementById("playButton").innerHTML = "►";
         }

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -35,28 +35,31 @@ function radioTitle() {
 
 // Toggle the stream with the playButton
 $(document).ready(function () {
-    document.getElementById("playButton").addEventListener('click', function(){
-        var stream = document.getElementById("stream");
-        var mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
+    var stream = document.getElementById("stream");
+    var mobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent);
 
-        // Here, we pause and play the stream
-        // If the device is mobile, we remove the stream source entirely
-        // so music data stops loading in the background.
+    if (!mobile) {
+        stream.src = "https://stream.cadenceradio.com/cadence1";
+        stream.load();
+    }
+
+    document.getElementById("playButton").addEventListener('click', function(){
         if (stream.paused) {
-            // Reload the audio source if on mobile
+            // Reload the audio source
             if (mobile) {
                 stream.src = "https://stream.cadenceradio.com/cadence1";
+                stream.load();
             }
-            stream.load();
             stream.play();
             // Replace the ❙❙ in the button when playing
             document.getElementById("playButton").innerHTML = "❙❙";
         } else {
-            // If mobile, clear the audio source
+            // Clear the audio source
             if (mobile) {
                 stream.src = "";
             }
             stream.load();
+            stream.pause();
             // Replace the ► in the button when paused
             document.getElementById("playButton").innerHTML = "►";
         }


### PR DESCRIPTION
PR makes a couple of simple logical changes to the play button function. It really makes a nice positive impact for all users.

1. When the stream is paused and the user hits "play", the `stream.load()` method no longer triggers for both mobile and non-mobile, instead triggering only for mobile only (Addresses #184). **As long as the desktop user is listening "normally" (not spamming the play/pause button every literal .7 seconds), they will have basically zero extra latency on-play.**

2. The stream source is removed from the `index.html` `src` attribute and instead only set on document-ready. This prevents any type of initial loading done on any browsers. Without it, all browsers (most importantly mobile) will waste a short of a second of load time, and almost three more seconds downloading a partial 150kb worth of stream. **Removing this, mobile users get much faster page "load" times which account for stall and time-to-first-byte of the stream, as well as save mobile users 150kb of data. This reduces the mobile page "loading spinner" time from 700-900ms to 150ms.**