### PR TITLE
Add Go linting Action and fix results

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,24 @@
+name: "PR"
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint-go:
+    name: Run Go Linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          cache: false
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: cadence/server/

--- a/cadence/server/api.go
+++ b/cadence/server/api.go
@@ -46,7 +46,11 @@ func Search() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("Search", "Failed to write response.", err)
+			return
+		}
 	}
 }
 
@@ -150,7 +154,11 @@ func NowPlayingMetadata() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("NowPlayingMetadata", "Failed to write response.", err)
+			return
+		}
 	}
 }
 
@@ -203,7 +211,11 @@ func NowPlayingAlbumArt() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("NowPlayingAlbumArt", "Failed to write response.", err)
+			return
+		}
 	}
 }
 
@@ -218,7 +230,11 @@ func History() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("History", "Failed to write response.", err)
+			return
+		}
 	}
 }
 
@@ -237,7 +253,11 @@ func ListenURL() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("ListenURL", "Failed to write response.", err)
+			return
+		}
 	}
 }
 
@@ -256,7 +276,11 @@ func Listeners() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("Listeners", "Failed to write response.", err)
+			return
+		}
 	}
 }
 
@@ -275,7 +299,11 @@ func Bitrate() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("Bitrate", "Failed to write response.", err)
+			return
+		}
 	}
 }
 
@@ -294,7 +322,11 @@ func Version() http.HandlerFunc {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write(jsonMarshal)
+		_, err = w.Write(jsonMarshal)
+		if err != nil {
+			clog.Error("Version", "Failed to write response.", err)
+			return
+		}
 	}
 }
 

--- a/cadence/server/api_actions.go
+++ b/cadence/server/api_actions.go
@@ -171,7 +171,11 @@ func filesystemMonitor() {
 					continue
 				}
 				clog.Info("fileSystemMonitor", "Change detected in music library.")
-				postgresPopulate()
+				err = postgresPopulate()
+				if err != nil {
+					clog.Error("fileSystemMonitor", "Failed to populate.", err)
+					return
+				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					continue

--- a/cadence/server/main.go
+++ b/cadence/server/main.go
@@ -59,10 +59,12 @@ func main() {
 	c.DevMode, _ = strconv.ParseBool(os.Getenv("CSERVER_DEVMODE"))
 
 	clog.Level(c.LogLevel)
-	clog.Debug("init", fmt.Sprintf("Cadence Logger initialized to level <%v>.", c.LogLevel))
+	clog.Debug("main", fmt.Sprintf("Cadence Logger initialized to level <%v>.", c.LogLevel))
 
 	if postgresInit() == nil {
-		postgresPopulate()
+		if postgresPopulate() != nil {
+			clog.Warn("main", "Initial database population failed.")
+		}
 	}
 	go redisInit()
 	go filesystemMonitor()


### PR DESCRIPTION
PR adds the repository's first Github Action, which lints all Go code under `cadence/server` for all pull requests to `master`. It additionally fixes the linter's suggestions that we handle any `w.Write` errors, which are now logged.