### PR TITLE
Set image versions to major or minor only

### DIFF
--- a/cadence/cadence-multiarch.Dockerfile
+++ b/cadence/cadence-multiarch.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20.1-bullseye as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20-bullseye as builder
 ARG TARGETPLATFORM BUILDPLATFORM TARGETOS TARGETARCH
 WORKDIR /cadence
 COPY ./* ./
@@ -7,7 +7,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o /cadence-server
 
 ARG ARCH=
-FROM ${ARCH}golang:1.20.1-alpine
+FROM ${ARCH}golang:1.20-alpine
 LABEL maintainer="Ken Ellorando (kenellorando.com)"
 LABEL source="github.com/kenellorando/cadence"
 COPY --from=builder /cadence/public /cadence/server/public

--- a/cadence/cadence.Dockerfile
+++ b/cadence/cadence.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG ARCH=
-FROM ${ARCH}golang:1.20.1-bullseye
+FROM ${ARCH}golang:1.20-bullseye
 LABEL maintainer="Ken Ellorando (kenellorando.com)"
 LABEL source="github.com/kenellorando/cadence"
 WORKDIR /cadence/server

--- a/cadence/icecast2.Dockerfile
+++ b/cadence/icecast2.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG ARCH=
-FROM ${ARCH}alpine:3.17
+FROM ${ARCH}alpine:3
 LABEL maintainer="Ken Ellorando (kenellorando.com)"
 LABEL source="github.com/kenellorando/cadence"
 RUN apk update && apk add icecast=2.4.4-r8

--- a/cadence/liquidsoap.Dockerfile
+++ b/cadence/liquidsoap.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG ARCH=
-FROM ${ARCH}debian:11.6-slim
+FROM ${ARCH}debian:11-slim
 LABEL maintainer="Ken Ellorando (kenellorando.com)"
 LABEL source="github.com/kenellorando/cadence"
 


### PR DESCRIPTION
PR removes specificity of base image versions where possible, preferring to specify only the major or minor version but removing all patch versions. This should give the image pull the flexibility to pull slightly updated versions.