### PR TITLE
Extend initial db delayed connect time

### DIFF
--- a/cadence/server/db_postgres.go
+++ b/cadence/server/db_postgres.go
@@ -20,7 +20,8 @@ var dbp *sql.DB
 
 func postgresInit() (err error) {
 	// We wait a bit to give some leeway for Postgres to finish startup.
-	time.Sleep(2 * time.Second)
+	// Obligatory: There's probably a better way to do this.
+	time.Sleep(5 * time.Second)
 	dsn := fmt.Sprintf("host='%s' port='%s' user='%s' password='%s' sslmode='%s'",
 		c.PostgresAddress, c.PostgresPort, c.PostgresUser, c.PostgresPassword, c.PostgresSSL)
 	dbp, err = sql.Open("postgres", dsn)


### PR DESCRIPTION
During periodic maintenance, I restarted the stack and noticed metadata DB functions were off. It seemed the Postgres container was taking longer than before to start. 

This PR increases the hardcoded delay Cadence waits before making the initial database connection. 

Looking for a more proper way to do this with retries or through Docker Compose. Until then, this should fix the stack.