### PR TITLE
Create build workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -30,9 +30,9 @@ jobs:
                   declare -a tags
                   for tag in ${{ github.inputs.tags }}
                   do
-                    tags+=("-t \$IMAGE:$tag")
+                    tags+=("$tag")
                   done
-                  tags+=("-t \$IMAGE:$(git rev-parse --short HEAD)")
+                  tags+=("$(git rev-parse --short HEAD)")
                   echo "tags=\"${tags[@]}\"" >> $GITHUB_ENV
             - name: Prepare tag list (push trigger)
               if: github.event_name != 'workflow_dispatch'
@@ -40,11 +40,11 @@ jobs:
                   release=$(git tag --points-at HEAD)
                   if $?
                   then
-                    release="-t \$IMAGE:$release"
+                    release="$release"
                   else
                     release=""
                   fi
-                  echo "tags=\"-t \$IMAGE:latest -t \$IMAGE:$(git rev-parse --short HEAD)\" $release" >> $GITHUB_ENV
+                  echo "tags=\"latest $(git rev-parse --short HEAD)\" $release" >> $GITHUB_ENV
             - name: Check push configuration
               run: |
                   auto=1
@@ -71,15 +71,30 @@ jobs:
             - name: Build Cadence server image
               run: |
                   IMAGE=kenellorando/cadence
-                  docker build ${{ env.tags }} -f src/cadence.Dockerfile src
+                  declare -a tags
+                  for tag in "${{ env.tags }}"
+                  do
+                    tags+=("-t $IMAGE:$tag")
+                  done
+                  docker build ${tags[@]} -f src/cadence.Dockerfile src
             - name: Build icecast2 image
               run: |
                   IMAGE=kenellorando/cadence_icecast2
-                  docker build ${{ env.tags }} -f src/icecast2.Dockerfile src
+                  declare -a tags
+                  for tag in "${{ env.tags }}"
+                  do
+                    tags+=("-t $IMAGE:$tag")
+                  done
+                  docker build ${tags[@]} -f src/icecast2.Dockerfile src
             - name: Build liquidsoap image
               run: |
                   IMAGE=kenellorando/cadence_liquidsoap
-                  docker build ${{ env.tags }} -f src/liquidsoap.Dockerfile src
+                  declare -a tags
+                  for tag in "${{ env.tags }}"
+                  do
+                    tags+=("-t $IMAGE:$tag")
+                  done
+                  docker build ${tags[@]} -f src/liquidsoap.Dockerfile src
             - name: Login to Docker Hub
               if: env.push == 'true'
               uses: docker/login-action@v3

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,79 @@
+name: "Docker Build and Push"
+
+on:
+    release:
+        types: ["published"]
+    push:
+        branches: ["master"]
+    pull_request:
+        branches: ["master"]
+    workflow_dispatch:
+        inputs:
+            push:
+                type: boolean
+                description: "Push image after build"
+                default: false
+            tags:
+                type: string
+                description: "Tags to apply to built image in addition to commit ID (separated by spaces)"
+                default: ""
+
+jobs:
+    build:
+        name: Build and push docker images
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Prepare tag list (manual trigger)
+              if: github.event_name == 'workflow_dispatch'
+              run: |
+                  declare -a tags
+                  for tag in ${{ github.inputs.tags }}
+                  do
+                    tags+=("-t \$IMAGE:$tag")
+                  done
+                  tags+=("-t \$IMAGE:$(git rev-parse --short HEAD)")
+                  echo "tags=\"${tags[@]}\"" >> $GITHUB_ENV
+            - name: Prepare tag list (push trigger)
+              if: github.event_name != 'workflow_dispatch'
+              run: |
+                  release=$(git tag --points-at HEAD)
+                  if $?
+                  then
+                    release="-t \$IMAGE:$release"
+                  else
+                    release=""
+                  fi
+                  echo "tags=\"-t \$IMAGE:latest -t \$IMAGE:$(git rev-parse --short HEAD)\" $release" >> $GITHUB_ENV
+            - name: Check push configuration
+              run: |
+                  auto=[ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]
+                  manual="${{ github.inputs.push }}"
+                  release=[ "${{ github.event_name }}" = "release" ]
+                  push=($auto || $manual || $release) && 'true' || 'false'
+                  echo "do_push=$push" >> $GITHUB_ENV
+            - name: Build Cadence server image
+              run: |
+                  IMAGE=kenellorando/cadence
+                  docker build ${{ env.tags }} -f src/cadence.Dockerfile src
+            - name: Build icecast2 image
+              run: |
+                  IMAGE=kenellorando/cadence_icecast2
+                  docker build ${{ env.tags }} -f src/icecast2.Dockerfile src
+            - name: Build liquidsoap image
+              run: |
+                  IMAGE=kenellorando/cadence_liquidsoap
+                  docker build ${{ env.tags }} -f src/liquidsoap.Dockerfile src
+            - name: Login to Docker Hub
+              if: env.push == 'true'
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKER_USERNAME }}
+                  password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+            - name: Push Cadence images
+              if: env.push == 'true'
+              run: |
+                  sha=$(git rev-parse --short HEAD)
+                  docker push --all-tags kenellorando/cadence:$sha
+                  docker push --all-tags kenellorando/cadence_icecast2:$sha
+                  docker push --all-tags kenellorando/cadence_liquidsoap:$sha

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -53,7 +53,7 @@ jobs:
                   manual=$?
                   [ "${{ github.event_name }}" = "release" ]
                   release=$?
-                  push=`[[ $auto || $manual || $release ]] && echo 'true' || echo 'false'`
+                  push=`[[ $auto -eq 0 || $manual -eq 0 || $release -eq 0 ]] && echo 'true' || echo 'false'`
                   echo "do_push=$push" >> $GITHUB_ENV
             - name: Build Cadence server image
               run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -71,30 +71,30 @@ jobs:
             - name: Build Cadence server image
               run: |
                   IMAGE=kenellorando/cadence
-                  declare -a tags
+                  declare -a flags
                   for tag in "${{ env.tags }}"
                   do
-                    tags+=("-t $IMAGE:$tag")
+                    flags+=("-t $IMAGE:$tag")
                   done
-                  docker build ${tags[@]} -f src/cadence.Dockerfile src
+                  docker build ${flags[@]} -f src/cadence.Dockerfile src
             - name: Build icecast2 image
               run: |
                   IMAGE=kenellorando/cadence_icecast2
-                  declare -a tags
+                  declare -a flags
                   for tag in "${{ env.tags }}"
                   do
-                    tags+=("-t $IMAGE:$tag")
+                    flags+=("-t $IMAGE:$tag")
                   done
-                  docker build ${tags[@]} -f src/icecast2.Dockerfile src
+                  docker build ${flags[@]} -f src/icecast2.Dockerfile src
             - name: Build liquidsoap image
               run: |
                   IMAGE=kenellorando/cadence_liquidsoap
-                  declare -a tags
+                  declare -a flags
                   for tag in "${{ env.tags }}"
                   do
-                    tags+=("-t $IMAGE:$tag")
+                    flags+=("-t $IMAGE:$tag")
                   done
-                  docker build ${tags[@]} -f src/liquidsoap.Dockerfile src
+                  docker build ${flags[@]} -f src/liquidsoap.Dockerfile src
             - name: Login to Docker Hub
               if: env.push == 'true'
               uses: docker/login-action@v3

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -38,12 +38,6 @@ jobs:
               if: github.event_name != 'workflow_dispatch'
               run: |
                   release=$(git tag --points-at HEAD)
-                  if $?
-                  then
-                    release="$release"
-                  else
-                    release=""
-                  fi
                   echo "tags=\"latest $(git rev-parse --short HEAD)\" $release" >> $GITHUB_ENV
             - name: Check push configuration
               run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,12 +47,25 @@ jobs:
                   echo "tags=\"-t \$IMAGE:latest -t \$IMAGE:$(git rev-parse --short HEAD)\" $release" >> $GITHUB_ENV
             - name: Check push configuration
               run: |
-                  [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]
-                  auto=$?
-                  [ "${{ github.inputs.push }}" = "true" ]
-                  manual=$?
-                  [ "${{ github.event_name }}" = "release" ]
-                  release=$?
+                  auto=1
+                  manual=1
+                  release=1
+
+                  if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]
+                  then
+                    auto=0
+                  fi
+
+                  if [ "${{ github.inputs.push }}" = "true" ]
+                  then
+                    manual=0
+                  fi
+
+                  if [ "${{ github.event_name }}" = "release" ]
+                  then
+                    release=0
+                  fi
+
                   push=`[[ $auto -eq 0 || $manual -eq 0 || $release -eq 0 ]] && echo 'true' || echo 'false'`
                   echo "do_push=$push" >> $GITHUB_ENV
             - name: Build Cadence server image

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,10 +47,12 @@ jobs:
                   echo "tags=\"-t \$IMAGE:latest -t \$IMAGE:$(git rev-parse --short HEAD)\" $release" >> $GITHUB_ENV
             - name: Check push configuration
               run: |
-                  auto=[ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]
+                  [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]
+                  auto=$?
                   manual="${{ github.inputs.push }}"
-                  release=[ "${{ github.event_name }}" = "release" ]
-                  push=($auto || $manual || $release) && 'true' || 'false'
+                  [ "${{ github.event_name }}" = "release" ]
+                  release=$?
+                  push=`($auto || $manual || $release) && echo 'true' || echo 'false'`
                   echo "do_push=$push" >> $GITHUB_ENV
             - name: Build Cadence server image
               run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -49,10 +49,11 @@ jobs:
               run: |
                   [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]
                   auto=$?
-                  manual="${{ github.inputs.push }}"
+                  [ "${{ github.inputs.push }}" = "true" ]
+                  manual=$?
                   [ "${{ github.event_name }}" = "release" ]
                   release=$?
-                  push=`($auto || $manual || $release) && echo 'true' || echo 'false'`
+                  push=`[[ $auto || $manual || $release ]] && echo 'true' || echo 'false'`
                   echo "do_push=$push" >> $GITHUB_ENV
             - name: Build Cadence server image
               run: |


### PR DESCRIPTION
Docker images will be built on any update to a pull request, on any push to main (including merges), on the publication of a new release, or when requested manually.

Docker images will then be pushed for any of those conditions except PRs or manual requests that do not explicitly request pushes.

Images will always be tagged with the short ID of the current commit. Manual runs can set whatever tags they like - Automatic runs will add 'latest', and the name of any tags pointing to the current commit (which is why this runs on release, to get the new tag). All of these tags will be pushed to Docker, should pushing occur.

Merging this PR will fix #252.