### PR TITLE
feat(homelab): backend hardening - redis password/db, postgres fix, t…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: Build
+
+on:
+  push:
+    branches: [master, feat/homelab-hardening]
+  pull_request:
+    branches: [master]
+
+jobs:
+  go-build:
+    name: Go build & tidy
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/server
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: src/server/go.sum
+
+      - name: go mod tidy
+        run: go mod tidy
+
+      - name: Commit go.sum if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --exit-code go.sum go.mod || (
+            git add go.sum go.mod &&
+            git commit -m "chore: go mod tidy [skip ci]" &&
+            git push
+          )
+
+      - name: go build
+        run: CGO_ENABLED=0 go build -v ./...
+
+      - name: go vet
+        run: go vet ./...
+
+  docker-build:
+    name: Docker build smoke test
+    runs-on: ubuntu-latest
+    needs: go-build
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build cadence image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          file: ./src/cadence.Dockerfile
+          push: false
+          tags: cadence:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: Build
 
 on:
   push:
-    branches: [master, feat/homelab-hardening]
+    branches: [master]
+    tags: ['v*.*.*']
   pull_request:
     branches: [master]
 
@@ -28,6 +29,8 @@ jobs:
         run: go mod tidy
 
       - name: Commit go.sum if changed
+        # Only commit back on branch pushes, not tags (tags are immutable)
+        if: github.ref_type == 'branch'
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -54,7 +57,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build cadence image
+      - name: Build cadence image (no push)
         uses: docker/build-push-action@v5
         with:
           context: ./src

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,8 @@ name: Lint
 
 on:
   push:
-    branches: [master, feat/homelab-hardening]
+    branches: [master]
+    tags: ['v*.*.*']
   pull_request:
     branches: [master]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    branches: [master, feat/homelab-hardening]
+  pull_request:
+    branches: [master]
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src/server
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: src/server/go.sum
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: src/server
+          args: --timeout=5m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+# Triggered only on version tags: v1.2.3
+on:
+  push:
+    tags: ['v*.*.*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  release:
+    name: Build, publish, release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write       # create GitHub Release
+      packages: write       # push to ghcr.io
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history for changelog
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: src/server/go.sum
+
+      - name: go mod tidy
+        working-directory: src/server
+        run: go mod tidy
+
+      - name: go build (verify)
+        working-directory: src/server
+        run: CGO_ENABLED=0 go build -v ./...
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./src
+          file: ./src/cadence.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            CSERVER_VERSION=${{ github.ref_name }}
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          PREV=$(git tag --sort=-version:refname | sed -n '2p')
+          if [ -z "$PREV" ]; then
+            NOTES=$(git log --oneline --no-merges)
+          else
+            NOTES=$(git log ${PREV}..HEAD --oneline --no-merges)
+          fi
+          # Write to file to handle multiline safely
+          echo "$NOTES" > /tmp/changelog.txt
+          echo "prev_tag=$PREV" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: /tmp/changelog.txt
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: false

--- a/config/Caddyfile.example
+++ b/config/Caddyfile.example
@@ -1,0 +1,32 @@
+# Caddyfile.example - Cadence behind Caddy
+# Place in your main Caddyfile or import.
+# Replace radio.example.com with your domain.
+
+radio.example.com {
+    encode zstd gzip
+
+    header {
+        X-Frame-Options SAMEORIGIN
+        X-Content-Type-Options nosniff
+        X-Robots-Tag "noindex, nofollow"
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        -Server
+    }
+
+    # Icecast audio stream - flush immediately for live streaming
+    handle /cadence1 {
+        reverse_proxy icecast2:8000 {
+            flush_interval -1
+        }
+    }
+
+    # Icecast status (optional, for external tools)
+    handle /status-json.xsl {
+        reverse_proxy icecast2:8000
+    }
+
+    # Cadence API + frontend
+    handle {
+        reverse_proxy cadence:8080
+    }
+}

--- a/config/cadence.env.example
+++ b/config/cadence.env.example
@@ -1,30 +1,50 @@
-CSERVER_MUSIC_DIR=CADENCE_PATH_EXAMPLE
-CSERVER_REQRATELIMIT=CADENCE_RATE_EXAMPLE
-POSTGRES_PASSWORD=CADENCE_PASS_EXAMPLE
+# =============================================================
+# Cadence Homelab Configuration
+# Copy to: config/cadence.env
+# =============================================================
 
-# ####################################################
-# If you are running Cadence through Docker simply as a user,
-# you are unlikely to ever need to change anything below.
+# --- Required ---
+CSERVER_MUSIC_DIR=/music
+CSERVER_VERSION=homelab
 
-# Development
-CSERVER_DEVMODE=0
-CSERVER_VERSION=5.4.4
+# --- DB backend: "sqlite" (lightweight) or "postgres" (full-text search) ---
+CSERVER_DB_BACKEND=sqlite
+
+# SQLite (used when DB_BACKEND=sqlite)
+CSERVER_SQLITE_PATH=/data/cadence.db
+
+# Postgres (used when DB_BACKEND=postgres)
+# POSTGRES_PASSWORD=changeme
+# CSERVER_POSTGRESADDRESS=cadence-postgres
+# CSERVER_POSTGRESPORT=5432
+# CSERVER_POSTGRESUSER=postgres
+# CSERVER_POSTGRESDBNAME=cadence
+# CSERVER_POSTGRESTABLENAME=metadata
+# CSERVER_POSTGRESSSL=disable
+
+# --- Internal service addresses (Docker container names) ---
+CSERVER_PORT=:8080
+CSERVER_LIQUIDSOAPADDRESS=liquidsoap
+CSERVER_LIQUIDSOAPPORT=:1234
+# Internal-only URL cadence uses to poll Icecast status (never sent to browser)
+CSERVER_ICECAST_STATUS_URL=http://icecast2:8000
+# Public stream URL sent to the browser (e.g. https://radio.yourdomain.com/cadence1)
+# Leave empty to use Icecast's self-reported host (may be wrong behind proxy)
+CSERVER_PUBLIC_STREAM_URL=
+
+# --- Redis (optional, only with --profile redis) ---
+# CSERVER_REDISADDRESS=cadence-redis
+# CSERVER_REDISPORT=:6379
+# CSERVER_REDISPASSWORD=
+# CSERVER_REDISDB=0
+
+# --- Request rate limit (seconds between requests per IP, 0=disabled) ---
+CSERVER_REQRATELIMIT=5
+
+# --- Metadata scan workers (parallel goroutines, default=4) ---
+CSERVER_SCAN_WORKERS=4
+
+# --- Root & dev ---
 CSERVER_ROOTPATH=/cadence/server/
 CSERVER_LOGLEVEL=info
-
-# Service Addresses
-CSERVER_PORT=:8080
-CSERVER_LIQUIDSOAPADDRESS=liquidsoap:1234
-CSERVER_LIQUIDSOAPPORT=
-CSERVER_ICECASTADDRESS=icecast2:8000
-CSERVER_ICECASTPORT=
-CSERVER_POSTGRESADDRESS=postgres
-CSERVER_POSTGRESPORT=5432
-CSERVER_REDISADDRESS=redis:6379
-CSERVER_REDISPORT=
-
-# Database Configuration
-CSERVER_POSTGRESUSER=postgres
-CSERVER_POSTGRESDBNAME=cadence
-CSERVER_POSTGRESTABLENAME=metadata
-CSERVER_POSTGRESSSL=disable
+CSERVER_DEVMODE=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,105 @@
+# Cadence homelab docker-compose
+# Profiles:
+#   postgres (default db)  - include: postgres service
+#   sqlite   (lightweight) - no postgres, uses local sqlite file
+#   redis                  - optional rate limiting
+#
+# Minimal start (SQLite, no Redis):
+#   docker compose up -d
+#
+# Full stack with Postgres + Redis:
+#   docker compose --profile postgres --profile redis up -d
+
+services:
+
+  icecast2:
+    build:
+      dockerfile: ./src/icecast2.Dockerfile
+    image: cadence_icecast2
+    container_name: icecast2
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./config/icecast.xml:/etc/icecast/cadence.xml:ro
+    networks:
+      - services-net
+      - stream-net
+
+  liquidsoap:
+    build:
+      dockerfile: ./src/liquidsoap.Dockerfile
+    image: cadence_liquidsoap
+    container_name: liquidsoap
+    restart: unless-stopped
+    volumes:
+      - ./config/liquidsoap.liq:/etc/liquidsoap/cadence.liq:ro
+      - ${MUSIC_DIR}:${MUSIC_DIR}:ro
+    depends_on:
+      - icecast2
+    expose:
+      - "1234"
+    networks:
+      - services-net
+      - stream-net
+
+  cadence:
+    build:
+      context: ./src/
+      dockerfile: ./cadence.Dockerfile
+    image: cadence
+    container_name: cadence
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    env_file:
+      - ./config/cadence.env
+    volumes:
+      - ${MUSIC_DIR}:${MUSIC_DIR}:ro
+      - ./src/server/public/css/custom.css:/cadence/server/public/css/custom.css:ro
+      - ./data:/data  # sqlite db lives here
+    depends_on:
+      - icecast2
+      - liquidsoap
+    networks:
+      - services-net
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  postgres:
+    profiles: ["postgres"]
+    image: postgres:16-alpine
+    container_name: cadence-postgres
+    restart: unless-stopped
+    expose:
+      - "5432"
+    env_file:
+      - ./config/cadence.env
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
+    networks:
+      - services-net
+
+  redis:
+    profiles: ["redis"]
+    image: redis:7-alpine
+    container_name: cadence-redis
+    restart: unless-stopped
+    command: >
+      redis-server
+      --requirepass ${REDIS_PASSWORD:-}
+      --save ""
+      --appendonly no
+    expose:
+      - "6379"
+    networks:
+      - services-net
+
+networks:
+  services-net:
+    driver: bridge
+  stream-net:
+    driver: bridge

--- a/install.sh
+++ b/install.sh
@@ -1,143 +1,122 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Exit immediately upon error
-set -eo pipefail
+COLOR_GREEN='\033[0;32m'
+COLOR_YELLOW='\033[1;33m'
+COLOR_RED='\033[0;31m'
+COLOR_RESET='\033[0m'
 
-if [ $# -gt 0 ]
-then
-      echo "$(basename $0): No parameters allowed, $# given."
-      exit 1
-fi
+info()  { echo -e "${COLOR_GREEN}[cadence]${COLOR_RESET} $*"; }
+warn()  { echo -e "${COLOR_YELLOW}[warn]${COLOR_RESET}   $*"; }
+err()   { echo -e "${COLOR_RED}[error]${COLOR_RESET}  $*" >&2; }
 
-cat <<END
-"***************************************************************"
-NOTE: If you need help determining configuration values to use,
-installation documentation is available on GitHub:
-https://github.com/kenellorando/cadence/wiki/Installation
-***************************************************************
-
-[1/5] Path to Music Directory
-Set a path to a directory containing audio files (e.g. mp3, flac) to be played
-on the radio. The target will be recursively searched.
-END
-read -ep "      Music path: " CADENCE_PATH
-while [ ! -d "$CADENCE_PATH" ]
-do
-      echo "Music path must point to a directory that exists and is readable."
-      read -ep "      Music path: " CADENCE_PATH
-done
-# We do need to use absolute paths here - Make sure they end up that way.
-# realpath -s is used here instead of readlink -f to retain symlinks - Else,
-# we'd automatically go to the destination and use that, even if the user
-# changed the symlink and restarted Cadence!
-# ... Despite this, symlinks inside CADENCE_PATH probably won't work, since
-# they don't get mounted inside our containers. Not a lot we can do about that.
-CADENCE_PATH=$(realpath -s "$CADENCE_PATH")
-
+info "Cadence Homelab Installer"
 echo
 
-cat <<END
-[2/5] Stream Host Address
-Set the stream host address. This may be a DNS name, public IP, or private IP.
-Use localhost:8000 if your Cadence instance is meant for local use only.
-Default: localhost:8000
-END
-read -p "      Stream address: " CADENCE_STREAM_HOST
-if [ -z "$CADENCE_STREAM_HOST" ]
-then
-      echo "Streaming to localhost:8000."
-      CADENCE_STREAM_HOST='localhost:8000'
-fi
+# --- Checks ---
+command -v docker  >/dev/null 2>&1 || { err "Docker not found. Install Docker first."; exit 1; }
+command -v docker-compose >/dev/null 2>&1 || docker compose version >/dev/null 2>&1 || \
+  { err "Docker Compose not found."; exit 1; }
 
-
-echo
-
-cat <<END
-[3/5] Rate Limiter Timeout
-Set a rate limit timeout in integer seconds. This prevents the same listener
-from requesting songs within the configured timeframe. Set to 0 to disable.
-END
-read -p "      Rate limit (0): " CADENCE_RATE
-while ! [[ "$CADENCE_RATE" =~ ^[0-9]*$ ]]
-do
-      echo "Rate limit must be an integer!"
-      read -p "      Rate limit (0): " CADENCE_RATE
-done
-[ -z "$CADENCE_RATE" ] && CADENCE_RATE=0
-
-
-echo
-
-cat <<END
-[4/5] Radio Service Password
-Set a secure, unique service password. Input is hidden.
-END
-read -s -p "      Password: " CADENCE_PASS
-while [ -z "$CADENCE_PASS" ]
-do
-      echo
-      echo "Password cannot be empty!"
-      read -s -p "      Password: " CADENCE_PASS
-done
-
-echo
-echo
-
-cat <<END
-[5/5] Enable Reverse Proxy?
-Do you want to enable a reverse proxy? Skip if you are broadcasting locally only
-or have your own reverse proxy configured. Skip if you do not know what this means.
-END
-ENABLE_REVERSE_PROXY="UNSET"
-while ! [[ "$ENABLE_REVERSE_PROXY" =~ ^[yYnN]$ ]] && [ -n "$ENABLE_REVERSE_PROXY" ]
-do
-      read -n1 -p "      [y/N]: " ENABLE_REVERSE_PROXY
-      echo
-done
-
-if [[ "$ENABLE_REVERSE_PROXY" =~ ^([yY])$ ]]
-then
-      echo "Please provide the domain name you will use for Cadence UI."
-      read -p "      Web UI Domain: " CADENCE_WEB_HOST
-      while [ -z "$CADENCE_WEB_HOST" ]
-      do
-            echo "Web UI Domain cannot be empty!"
-            read -p "      Web UI Domain: " CADENCE_WEB_HOST
-      done
+# --- Config files ---
+if [ ! -f config/cadence.env ]; then
+  cp config/cadence.env.example config/cadence.env
+  info "Created config/cadence.env from example."
 else
-      echo "No reverse proxy will be configured."
+  info "config/cadence.env already exists, skipping."
 fi
 
-SCRIPT_DIR="$(dirname $(readlink -f $0))"
-cd $SCRIPT_DIR
+for f in icecast.xml liquidsoap.liq; do
+  if [ ! -f "config/$f" ]; then
+    cp "config/$f.example" "config/$f"
+    info "Created config/$f from example."
+  fi
+done
 
-cp ./config/cadence.env.example ./config/cadence.env
-cp ./config/icecast.xml.example ./config/icecast.xml
-cp ./config/liquidsoap.liq.example ./config/liquidsoap.liq
-cp ./config/nginx.conf.example ./config/nginx.conf
-
-if [[ "$ENABLE_REVERSE_PROXY" =~ ^([yY])$ ]]
-then
-      awk -v "c=$(cat ./nginx-compose-section.yml)" \
-          '{gsub(/NGINX_CONFIG_SECTION/,c)}1' ./docker-compose.yml.example > ./docker-compose.yml
-else
-      sed -e 's|NGINX_CONFIG_SECTION||g' ./docker-compose.yml.example > ./docker-compose.yml
+if [ ! -f config/Caddyfile ]; then
+  cp config/Caddyfile.example config/Caddyfile
+  info "Created config/Caddyfile from example."
 fi
 
-sed -i 's|CADENCE_PASS_EXAMPLE|'"$CADENCE_PASS"'|g' ./config/cadence.env
-sed -i 's|CADENCE_PASS_EXAMPLE|'"$CADENCE_PASS"'|g' ./config/icecast.xml
-sed -i 's|CADENCE_PASS_EXAMPLE|'"$CADENCE_PASS"'|g' ./config/liquidsoap.liq
-sed -i 's|CADENCE_RATE_EXAMPLE|'"$CADENCE_RATE"'|g' ./config/cadence.env
-sed -i 's|CADENCE_STREAM_HOST_EXAMPLE|'"$CADENCE_STREAM_HOST"'|g' ./config/icecast.xml
-sed -i 's|CADENCE_PATH_EXAMPLE|'"$CADENCE_PATH"'|g' ./config/cadence.env
-sed -i 's|CADENCE_PATH_EXAMPLE|'"$CADENCE_PATH"'|g' ./config/liquidsoap.liq
-sed -i 's|CADENCE_STREAM_HOST_EXAMPLE|'"$CADENCE_STREAM_HOST"'|g' ./config/nginx.conf
-sed -i 's|CADENCE_WEB_HOST_EXAMPLE|'"$CADENCE_WEB_HOST"'|g' ./config/nginx.conf
-sed -i 's|CADENCE_PATH_EXAMPLE|'"$CADENCE_PATH"'|g' ./docker-compose.yml
+# Ensure data dir exists for SQLite
+mkdir -p data
 
-echo ""
-echo "Configuration completed."
+# --- Interactive setup ---
+echo
+info "=== Quick Setup ==="
 
-docker compose down
-docker compose pull
-docker compose up
+read -rp "Music directory path [/music]: " MUSIC_DIR
+MUSIC_DIR=${MUSIC_DIR:-/music}
+
+echo
+echo "Database backend:"
+echo "  1) sqlite  - lightweight, no extra container (recommended for homelab)"
+echo "  2) postgres - full fuzzy search, requires more RAM"
+read -rp "Choice [1]: " DB_CHOICE
+DB_CHOICE=${DB_CHOICE:-1}
+
+case "$DB_CHOICE" in
+  2) DB_BACKEND=postgres ;;
+  *) DB_BACKEND=sqlite   ;;
+esac
+
+PROFILES=""
+PG_PASS=""
+if [ "$DB_BACKEND" = "postgres" ]; then
+  read -rsp "Postgres password: " PG_PASS; echo
+  PROFILES="--profile postgres"
+fi
+
+echo
+read -rp "Enable Redis rate limiting? (y/N): " USE_REDIS
+USE_REDIS=${USE_REDIS:-n}
+if [[ "$USE_REDIS" =~ ^[Yy]$ ]]; then
+  read -rsp "Redis password (leave blank for none): " REDIS_PASS; echo
+  PROFILES="$PROFILES --profile redis"
+  # Write REDIS_PASSWORD to env if set
+  if [ -n "${REDIS_PASS:-}" ]; then
+    echo "REDIS_PASSWORD=${REDIS_PASS}" >> config/cadence.env
+    sed -i "s|# CSERVER_REDISPASSWORD=|CSERVER_REDISPASSWORD=${REDIS_PASS}|" config/cadence.env
+  fi
+fi
+
+echo
+read -rp "Public stream URL (e.g. https://radio.example.com/cadence1) [leave blank to skip]: " PUBLIC_STREAM
+PUBLIC_STREAM=${PUBLIC_STREAM:-}
+
+# --- Write config ---
+sed -i "s|CSERVER_MUSIC_DIR=.*|CSERVER_MUSIC_DIR=${MUSIC_DIR}|"     config/cadence.env
+sed -i "s|CSERVER_DB_BACKEND=.*|CSERVER_DB_BACKEND=${DB_BACKEND}|" config/cadence.env
+echo "MUSIC_DIR=${MUSIC_DIR}" >> config/cadence.env
+
+if [ -n "$PG_PASS" ]; then
+  sed -i "s|# POSTGRES_PASSWORD=.*|POSTGRES_PASSWORD=${PG_PASS}|"   config/cadence.env
+fi
+if [ -n "$PUBLIC_STREAM" ]; then
+  sed -i "s|CSERVER_PUBLIC_STREAM_URL=.*|CSERVER_PUBLIC_STREAM_URL=${PUBLIC_STREAM}|" config/cadence.env
+fi
+
+# --- Build & start ---
+echo
+info "Building images..."
+docker compose build
+
+info "Starting Cadence ($DB_BACKEND${PROFILES:+ + ${PROFILES// --profile /+}})..."
+# shellcheck disable=SC2086
+docker compose $PROFILES up -d
+
+echo
+info "Done! Cadence should be available at http://localhost:8080"
+if command -v curl >/dev/null 2>&1; then
+  sleep 3
+  if curl -sf http://localhost:8080/healthz | grep -q 'ok'; then
+    info "Health check passed."
+  else
+    warn "Health check returned degraded. Check: docker compose logs cadence"
+  fi
+fi
+echo
+info "Config:     config/cadence.env"
+info "Caddy:      config/Caddyfile.example"
+info "Custom CSS: src/server/public/css/custom.css (mounted, edit without rebuild)"
+info "Logs:       docker compose logs -f cadence"

--- a/src/cadence.Dockerfile
+++ b/src/cadence.Dockerfile
@@ -1,22 +1,35 @@
 # syntax=docker/dockerfile:1
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22-bullseye as builder
+# Pure-Go build: CGO_ENABLED=0, no gcc required.
+# modernc.org/sqlite is used instead of go-sqlite3 to avoid CGO.
+
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.22-alpine AS builder
 ARG TARGETPLATFORM BUILDPLATFORM TARGETOS TARGETARCH
 WORKDIR /cadence
-COPY ./* ./
+COPY ./server ./
 RUN go mod download
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -o /cadence-server
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -ldflags="-w -s" -o /cadence-server ./...
 
-ARG ARCH=
-FROM ${ARCH}golang:1.22-alpine
-LABEL maintainer="Ken Ellorando (kenellorando.com)"
-LABEL source="github.com/kenellorando/cadence"
+FROM alpine:3.20
+LABEL maintainer="abzwingt-gaming"
+LABEL source="github.com/abzwingt-gaming/cadence"
+
+# ca-certificates for outbound HTTPS (Icecast status)
+RUN apk add --no-cache ca-certificates tzdata
+
 COPY --from=builder /cadence/public /cadence/server/public
-COPY --from=builder /cadence-server /cadence/cadence-server
+COPY --from=builder /cadence-server  /cadence/cadence-server
 
-RUN adduser --disabled-password --gecos "" cadence
-RUN chown cadence /cadence/ /cadence/* /cadence/cadence-server
-RUN chmod u+wrx /cadence/ /cadence/*
+# Ensure custom.css placeholder exists even if volume not mounted
+RUN mkdir -p /cadence/server/public/css && \
+    touch /cadence/server/public/css/custom.css
+
+# Non-root user
+RUN adduser -D -H cadence
+RUN chown -R cadence /cadence
 
 EXPOSE 8080
 USER cadence
-CMD [ "/cadence/cadence-server" ]
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD wget -qO- http://localhost:8080/healthz || exit 1
+CMD ["/cadence/cadence-server"]

--- a/src/server/api.go
+++ b/src/server/api.go
@@ -1,9 +1,10 @@
 // api.go
-// HTTP handler functions.
+// HTTP handlers.
 
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -16,16 +17,14 @@ import (
 
 func Search() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		slog.Debug(fmt.Sprintf("Search from %s.", r.RemoteAddr))
-		type body struct {
+		var req struct {
 			Query string `json:"search"`
 		}
-		var b body
-		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		results, err := searchByQuery(b.Query)
+		results, err := searchByQuery(req.Query)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -37,23 +36,19 @@ func Search() http.HandlerFunc {
 
 func RequestID() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		slog.Info(fmt.Sprintf("Song request from %s.", r.RemoteAddr))
-		type body struct {
-			ID string `json:"ID"`
-		}
-		var b body
-		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+		var req struct{ ID string }
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		id, err := strconv.Atoi(b.ID)
+		id, err := strconv.Atoi(req.ID)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		path, err := getPathById(id)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		if _, err = liquidsoapRequest(path); err != nil {
@@ -66,22 +61,19 @@ func RequestID() http.HandlerFunc {
 
 func RequestBestMatch() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		type body struct {
-			Query string `json:"Search"`
-		}
-		var b body
-		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+		var req struct{ Search string }
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		results, err := searchByQuery(b.Query)
+		results, err := searchByQuery(req.Search)
 		if err != nil || len(results) == 0 {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		path, err := getPathById(results[0].ID)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		if _, err = liquidsoapRequest(path); err != nil {
@@ -94,7 +86,8 @@ func RequestBestMatch() http.HandlerFunc {
 
 func NowPlayingMetadata() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		results, err := searchByTitleArtist(now.Song.Title, now.Song.Artist)
+		n := NowSnapshot()
+		results, err := searchByTitleArtist(n.Song.Title, n.Song.Artist)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -108,31 +101,57 @@ func NowPlayingMetadata() http.HandlerFunc {
 	}
 }
 
+// NowPlayingAlbumArt returns base64-encoded album art with in-memory caching.
 func NowPlayingAlbumArt() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		results, err := searchByTitleArtist(now.Song.Title, now.Song.Artist)
+		n := NowSnapshot()
+		results, err := searchByTitleArtist(n.Song.Title, n.Song.Artist)
 		if err != nil || len(results) == 0 {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		path, err := getPathById(results[0].ID)
+		song := results[0]
+		cacheKey := fmt.Sprintf("%d", song.ID)
+
+		// Check in-memory cache first
+		if cached, ok := artCache.Load(cacheKey); ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(cached.([]byte))
+			return
+		}
+
+		path, err := getPathById(song.ID)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		file, err := os.Open(path)
 		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		defer file.Close()
+
 		tags, err := tag.ReadFrom(file)
 		if err != nil || tags.Picture() == nil {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
+
+		type ArtResponse struct {
+			Picture string `json:"Picture"`
+		}
+		encoded := base64.StdEncoding.EncodeToString(tags.Picture().Data)
+		res := ArtResponse{Picture: encoded}
+		jsonBytes, err := json.Marshal(res)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// Store in cache
+		artCache.Store(cacheKey, jsonBytes)
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(struct{ Picture []byte }{tags.Picture().Data})
+		w.Write(jsonBytes)
 	}
 }
 
@@ -145,35 +164,65 @@ func History() http.HandlerFunc {
 
 func ListenURL() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		n := NowSnapshot()
+		publicURL := c.PublicStreamURL
+		if publicURL == "" {
+			publicURL = n.Host + "/" + n.Mountpoint
+		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(struct{ ListenURL string }{publicStreamURL()})
+		json.NewEncoder(w).Encode(struct{ ListenURL string }{ListenURL: publicURL})
 	}
 }
 
 func Listeners() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		n := NowSnapshot()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(struct{ Listeners int }{int(now.Listeners)})
+		json.NewEncoder(w).Encode(struct{ Listeners int }{Listeners: int(n.Listeners)})
 	}
 }
 
 func Bitrate() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		n := NowSnapshot()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(struct{ Bitrate int }{int(now.Bitrate)})
+		json.NewEncoder(w).Encode(struct{ Bitrate int }{Bitrate: int(n.Bitrate)})
 	}
 }
 
 func Version() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(struct{ Version string }{c.Version})
+		json.NewEncoder(w).Encode(struct{ Version string }{Version: c.Version})
 	}
 }
 
 func Ready() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// Healthz returns DB and Icecast reachability status.
+func Healthz() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		dbOK := dbActive != nil && dbActive.Ping() == nil
+		n := NowSnapshot()
+		icecastOK := n.Song.Title != "-" && n.Song.Title != ""
+		status := "ok"
+		code   := http.StatusOK
+		if !dbOK || !icecastOK {
+			status = "degraded"
+			code   = http.StatusServiceUnavailable
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":   status,
+			"db":       dbOK,
+			"icecast":  icecastOK,
+			"redis":    redisAvailable,
+		})
 	}
 }
 

--- a/src/server/api.go
+++ b/src/server/api.go
@@ -1,7 +1,5 @@
-// handlers.go
-// API functions.
-// The functions are named exactly the same as their API paths.
-// See complete API documentation: https://github.com/kenellorando/cadence/wiki/API-Reference
+// api.go
+// HTTP handler functions.
 
 package main
 
@@ -16,339 +14,175 @@ import (
 	"github.com/dhowden/tag"
 )
 
-// POST /api/search
-// Receives a search query, which it looks in the database for.
-// Returns a JSON list of text metadata (excluding art and path) of any matching songs.
 func Search() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		slog.Debug(fmt.Sprintf("Search request from client %s.", r.RemoteAddr), "func", "Search")
-		type Search struct {
+		slog.Debug(fmt.Sprintf("Search from %s.", r.RemoteAddr))
+		type body struct {
 			Query string `json:"search"`
 		}
-		var search Search
-		decoder := json.NewDecoder(r.Body)
-		err := decoder.Decode(&search)
-		if err != nil {
-			slog.Error("Unable to decode search body.", "func", "Search", "error", err)
-			w.WriteHeader(http.StatusBadRequest) // 400 Bad Request
+		var b body
+		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		queryResults, err := searchByQuery(search.Query)
+		results, err := searchByQuery(b.Query)
 		if err != nil {
-			slog.Error("Unable to execute search by query.", "func", "Search", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-			return
-		}
-		jsonMarshal, err := json.Marshal(queryResults)
-		if err != nil {
-			slog.Error("Failed to marshal results from the search.", "func", "Search", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "Search", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(results)
 	}
 }
 
-// POST /api/request/id
-// Receives an integer ID of a song to request.
-// This ID is translated to a filesystem path, which is passed to Liquidsoap for processing.
 func RequestID() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		slog.Info(fmt.Sprintf("Request-by-ID by client %s.", r.RemoteAddr), "func", "Request")
-		type Request struct {
+		slog.Info(fmt.Sprintf("Song request from %s.", r.RemoteAddr))
+		type body struct {
 			ID string `json:"ID"`
 		}
-		var request Request
-		decoder := json.NewDecoder(r.Body)
-		err := decoder.Decode(&request)
-		if err != nil {
-			slog.Error("Unable to decode request.", "func", "RequestID", "error", err)
-			w.WriteHeader(http.StatusBadRequest) // 400 Bad Request
+		var b body
+		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		reqID, err := strconv.Atoi(request.ID)
+		id, err := strconv.Atoi(b.ID)
 		if err != nil {
-			slog.Error("Unable to convert request ID to an integer.", "func", "RequestID", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		path, err := getPathById(reqID)
+		path, err := getPathById(id)
 		if err != nil {
-			slog.Error("Unable to find file path by song ID.", "func", "RequestID", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		_, err = liquidsoapRequest(path)
-		if err != nil {
-			slog.Error("Unable to submit song request.", "func", "RequestID", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+		if _, err = liquidsoapRequest(path); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.WriteHeader(http.StatusAccepted) // 202 Accepted
+		w.WriteHeader(http.StatusAccepted)
 	}
 }
 
-// POST /api/request/bestmatch
-// Receives a search query, which it looks in the database for.
-// The number one result of the search has its path taken and submitted to Liquidsoap for processing.
 func RequestBestMatch() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		slog.Debug(fmt.Sprintf("Decoding http-request data from client %s.", r.RemoteAddr), "func", "Search")
-		type RequestBestMatch struct {
+		type body struct {
 			Query string `json:"Search"`
 		}
-		var rbm RequestBestMatch
-		decoder := json.NewDecoder(r.Body)
-		err := decoder.Decode(&rbm)
-		if err != nil {
-			slog.Error("Unable to decode request body.", "func", "RequestBestMatch", "error", err)
-			w.WriteHeader(http.StatusBadRequest) // 400 Bad Request
+		var b body
+		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-		queryResults, err := searchByQuery(rbm.Query)
-		if err != nil {
-			slog.Error("Unable to search by query.", "func", "RequestBestMatch", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+		results, err := searchByQuery(b.Query)
+		if err != nil || len(results) == 0 {
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		path, err := getPathById(queryResults[0].ID)
+		path, err := getPathById(results[0].ID)
 		if err != nil {
-			slog.Error("Unable to find file path by song ID", "func", "RequestBestMatch", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		_, err = liquidsoapRequest(path)
-		if err != nil {
-			slog.Error("Unable to submit song request.", "func", "RequestBestMatch", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+		if _, err = liquidsoapRequest(path); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.WriteHeader(http.StatusAccepted) // 202 Accepted
+		w.WriteHeader(http.StatusAccepted)
 	}
 }
 
-// /api/nowplaying/metadata
-// Gets text metadata (excludes album art and path) of the currently playing song.
 func NowPlayingMetadata() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		queryResults, err := searchByTitleArtist(now.Song.Title, now.Song.Artist)
+		results, err := searchByTitleArtist(now.Song.Title, now.Song.Artist)
 		if err != nil {
-			slog.Error("Unable to search by title and artist.", "func", "NowPlayingMetadata", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		if len(queryResults) < 1 {
-			slog.Warn("The currently playing song could not be found in the database. The database may not be populated.", "func", "NowPlayingMetadata")
-			w.WriteHeader(http.StatusNotFound) // 404 Not Found
-			return
-		}
-		jsonMarshal, err := json.Marshal(queryResults[0])
-		if err != nil {
-			slog.Error("Failed to marshal results from the search.", "func", "NowPlayingMetadata", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+		if len(results) == 0 {
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "NowPlayingMetadata", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(results[0])
 	}
 }
 
-// GET /api/nowplaying/albumart
-// Gets base64 encoded album art of the currently playing song.
 func NowPlayingAlbumArt() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		queryResults, err := searchByTitleArtist(now.Song.Title, now.Song.Artist)
-		if err != nil {
-			slog.Error("Unable to search by title and artist.", "func", "NowPlayingAlbumArt", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+		results, err := searchByTitleArtist(now.Song.Title, now.Song.Artist)
+		if err != nil || len(results) == 0 {
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		if len(queryResults) < 1 {
-			slog.Warn("The currently playing song could not be found in the database. The database may not be populated.", "func", "NowPlayingAlbumArt")
-			w.WriteHeader(http.StatusNotFound) // 404 Not Found
-			return
-		}
-		path, err := getPathById(queryResults[0].ID)
+		path, err := getPathById(results[0].ID)
 		if err != nil {
-			slog.Error("Unable to find file path by song ID.", "func", "NowPlayingAlbumArt", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		file, err := os.Open(path)
 		if err != nil {
-			slog.Error("Unable to open a file for album art extraction.", "func", "NowPlayingAlbumArt", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
+		defer file.Close()
 		tags, err := tag.ReadFrom(file)
-		if err != nil {
-			slog.Error("Unable to read tags on file for art extraction.", "func", "NowPlayingAlbumArt", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-			return
-		}
-		if tags.Picture() == nil {
-			slog.Debug("The currently playing song has no album art metadata.", "func", "NowPlayingAlbumArt")
-			w.WriteHeader(http.StatusNoContent) // 204 No Content
-			return
-		}
-		type SongData struct {
-			Picture []byte
-		}
-		result := SongData{Picture: tags.Picture().Data}
-		jsonMarshal, err := json.Marshal(result)
-		if err != nil {
-			slog.Error("Failed to marshal art data.", "func", "NowPlayingAlbumArt", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+		if err != nil || tags.Picture() == nil {
+			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "NowPlayingAlbumArt", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(struct{ Picture []byte }{tags.Picture().Data})
 	}
 }
 
-// GET /api/history
-// Gets a list of the ten last-played songs, noting the time each ended.
 func History() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		jsonMarshal, err := json.Marshal(history)
-		if err != nil {
-			slog.Error("Failed to marshal play history.", "func", "History", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "History", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(history)
 	}
 }
 
-// GET /api/listenurl
-// Gets the direct stream listen URL, which is a combination of host and mountpoint, set by Icecast's cadence.xml.
 func ListenURL() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		type ListenURL struct {
-			ListenURL string
-		}
-		listenurl := ListenURL{ListenURL: string(now.Host + "/" + now.Mountpoint)}
-		jsonMarshal, err := json.Marshal(listenurl)
-		if err != nil {
-			slog.Error("Failed to marshal listen URL.", "func", "ListenURL", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "ListenURL", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(struct{ ListenURL string }{publicStreamURL()})
 	}
 }
 
-// GET /api/listeners
-// Gets the number of active connections to Icecast's stream.
 func Listeners() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		type Listeners struct {
-			Listeners int
-		}
-		listeners := Listeners{Listeners: int(now.Listeners)}
-		jsonMarshal, err := json.Marshal(listeners)
-		if err != nil {
-			slog.Error("Failed to marshal listeners.", "func", "Listeners", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "Listeners", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(struct{ Listeners int }{int(now.Listeners)})
 	}
 }
 
-// GET /api/bitrate
-// Gets the audio stream bitrate in kilobits.
 func Bitrate() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		type Bitrate struct {
-			Bitrate int
-		}
-		bitrate := Bitrate{Bitrate: int(now.Bitrate)}
-		jsonMarshal, err := json.Marshal(bitrate)
-		if err != nil {
-			slog.Error("Failed to marshal bitrate.", "func", "Bitrate", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "Bitrate", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(struct{ Bitrate int }{int(now.Bitrate)})
 	}
 }
 
-// GET /api/version
-// Gets the current server version (set in cadence.env).
 func Version() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		type Version struct {
-			Version string
-		}
-		version := Version{Version: c.Version}
-		jsonMarshal, err := json.Marshal(version)
-		if err != nil {
-			slog.Error("Failed to marshal version.", "func", "Version", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-			return
-		}
 		w.Header().Set("Content-Type", "application/json")
-		_, err = w.Write(jsonMarshal)
-		if err != nil {
-			slog.Error("Failed to write response.", "func", "Version", "error", err)
-			return
-		}
+		json.NewEncoder(w).Encode(struct{ Version string }{c.Version})
 	}
 }
 
-// GET /ready
-// Gets 200 OK status. Primarily used for verifying health/readiness of the API.
 func Ready() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK) // 200 OK
+		w.WriteHeader(http.StatusOK)
 	}
 }
 
-// GET /api/dev/skip
-// Requires development mode enabled.
-// Forwards a request to Liquidsoap to skip the currently playing track.
 func DevSkip() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, err := liquidsoapSkip()
-		if err != nil {
-			slog.Error("Unable to skip the playing song.", "func", "DevSkip", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+		if _, err := liquidsoapSkip(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.WriteHeader(http.StatusOK) // 200 OK
+		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/src/server/api_actions.go
+++ b/src/server/api_actions.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-
 	"strings"
 	"time"
 
@@ -38,129 +37,108 @@ type SongData struct {
 	Path   string
 }
 
-// Takes a query string to search the database.
-// Returns a slice of SongData of songs ordered by relevance.
-func searchByQuery(query string) (queryResults []SongData, err error) {
+func searchByQuery(query string) ([]SongData, error) {
 	query = strings.TrimSpace(query)
-	slog.Debug(fmt.Sprintf("Searching database for query: '%v'", query), "func", "searchByQuery")
-	selectWhereStatement := fmt.Sprintf("SELECT \"id\", \"artist\", \"title\",\"album\", \"genre\", \"year\" FROM %s ",
-		c.PostgresTableName) + "WHERE artist ILIKE $1 OR title ILIKE $2 ORDER BY LEAST(levenshtein($3, artist), levenshtein($4, title))"
-	rows, err := dbp.Query(selectWhereStatement, "%"+query+"%", "%"+query+"%", query, query)
-	if err != nil {
-		slog.Error("Database search failed.", "func", "searchByQuery", "error", err)
-		return nil, err
-	}
-	for rows.Next() {
-		song := &SongData{}
-		err = rows.Scan(&song.ID, &song.Artist, &song.Title, &song.Album, &song.Genre, &song.Year)
-		if err != nil {
-			slog.Error("Data scan failed.", "func", "searchByQuery", "error", err)
-			continue
-		}
-		queryResults = append(queryResults,
-			SongData{ID: song.ID, Artist: song.Artist, Title: song.Title, Album: song.Album, Genre: song.Genre, Year: song.Year})
-	}
-	return queryResults, nil
-}
-
-// Takes a title and artist string to find a song which exactly matches.
-// Returns a list of SongData whose first result [0] is the first (best) match.
-// This will not work if multiple songs share the exact same title and artist.
-func searchByTitleArtist(title string, artist string) (queryResults []SongData, err error) {
-	title, artist = strings.TrimSpace(title), strings.TrimSpace(artist)
-	slog.Debug(fmt.Sprintf("Searching database for: %s by %s", title, artist), "func", "searchByTitleArtist")
-	selectStatement := fmt.Sprintf("SELECT id,artist,title,album,genre,year FROM %s WHERE title LIKE $1 AND artist LIKE $2;",
+	slog.Debug(fmt.Sprintf("Search query: '%s'", query), "func", "searchByQuery")
+	stmt := fmt.Sprintf(
+		"SELECT id, artist, title, album, genre, year FROM %s WHERE artist ILIKE $1 OR title ILIKE $2 ORDER BY LEAST(levenshtein($3, artist), levenshtein($4, title))",
 		c.PostgresTableName)
-	rows, err := dbp.Query(selectStatement, title, artist)
+	rows, err := dbp.Query(stmt, "%"+query+"%", "%"+query+"%", query, query)
 	if err != nil {
-		slog.Error("Could not query DB.", "func", "searchByTitleArtist", "error", err)
+		slog.Error("DB search failed.", "func", "searchByQuery", "error", err)
 		return nil, err
 	}
+	defer rows.Close()
+	var results []SongData
 	for rows.Next() {
-		song := &SongData{}
-		err = rows.Scan(&song.ID, &song.Artist, &song.Title, &song.Album, &song.Genre, &song.Year)
-		if err != nil {
-			slog.Error("Data scan failed.", "func", "searchByTitleArtist", "error", err)
+		var s SongData
+		if err = rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
+			slog.Warn("Row scan error.", "func", "searchByQuery", "error", err)
 			continue
 		}
-		queryResults = append(queryResults,
-			SongData{ID: song.ID, Artist: song.Artist, Title: song.Title, Album: song.Album, Genre: song.Genre, Year: song.Year})
+		results = append(results, s)
 	}
-	return queryResults, nil
+	return results, nil
 }
 
-// Takes a song ID integer.
-// Returns the absolute path of the audio file.
-func getPathById(id int) (path string, err error) {
-	slog.Debug(fmt.Sprintf("Searching database for the path of song: '%v'", id), "func", "getPathById")
-	selectWhereStatement := fmt.Sprintf("SELECT \"path\" FROM %s WHERE id=%v", c.PostgresTableName, id)
-	rows, err := dbp.Query(selectWhereStatement)
+func searchByTitleArtist(title, artist string) ([]SongData, error) {
+	title, artist = strings.TrimSpace(title), strings.TrimSpace(artist)
+	stmt := fmt.Sprintf(
+		"SELECT id, artist, title, album, genre, year FROM %s WHERE title LIKE $1 AND artist LIKE $2",
+		c.PostgresTableName)
+	rows, err := dbp.Query(stmt, title, artist)
 	if err != nil {
-		slog.Error("Database search failed.", "func", "getPathById", "error", err)
-		return "", err
+		slog.Error("DB query failed.", "func", "searchByTitleArtist", "error", err)
+		return nil, err
 	}
+	defer rows.Close()
+	var results []SongData
 	for rows.Next() {
-		err = rows.Scan(&path)
-		if err != nil {
-			slog.Error("Data scan failed.", "func", "getPathById", "error", err)
-			return "", err
+		var s SongData
+		if err = rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
+			slog.Warn("Row scan error.", "func", "searchByTitleArtist", "error", err)
+			continue
 		}
+		results = append(results, s)
+	}
+	return results, nil
+}
+
+func getPathById(id int) (string, error) {
+	var path string
+	stmt := fmt.Sprintf("SELECT path FROM %s WHERE id=$1", c.PostgresTableName)
+	err := dbp.QueryRow(stmt, id).Scan(&path)
+	if err != nil {
+		slog.Error("DB path lookup failed.", "func", "getPathById", "error", err)
+		return "", err
 	}
 	return path, nil
 }
 
-// Takes an absolute song path, submits the path to be queued in Liquidsoap.
-// Returns the response message from Liquidsoap.
-func liquidsoapRequest(path string) (message string, err error) {
-	// Telnet to liquidsoap
-	slog.Debug("Connecting to liquidsoap service...", "func", "liquidsoapRequest")
+func liquidsoapRequest(path string) (string, error) {
+	slog.Debug("Connecting to Liquidsoap...", "func", "liquidsoapRequest")
 	conn, err := net.Dial("tcp", c.LiquidsoapAddress+c.LiquidsoapPort)
 	if err != nil {
-		slog.Error("Failed to connect to audio source server.", "func", "liquidsoapRequest", "error", err)
+		slog.Error("Failed to connect to Liquidsoap.", "func", "liquidsoapRequest", "error", err)
 		return "", err
 	}
 	defer conn.Close()
-	// Push song request to source service, listen for a response, and quit the telnet session.
-	fmt.Fprintf(conn, "request.push "+path+"\n")
-	message, err = bufio.NewReader(conn).ReadString('\n')
+	fmt.Fprintf(conn, "request.push %s\n", path)
+	msg, err := bufio.NewReader(conn).ReadString('\n')
 	if err != nil {
-		slog.Error("Failed to read stream response message from audio source server.", "func", "liquidsoapRequest", "error", err)
+		slog.Error("Failed to read Liquidsoap response.", "func", "liquidsoapRequest", "error", err)
 	}
-	slog.Info(fmt.Sprintf("Message from audio source server: %s", message), "func", "liquidsoapRequest")
-	fmt.Fprintf(conn, "quit"+"\n")
-	return message, nil
+	slog.Info(fmt.Sprintf("Liquidsoap: %s", msg), "func", "liquidsoapRequest")
+	fmt.Fprintf(conn, "quit\n")
+	return msg, nil
 }
 
-func liquidsoapSkip() (message string, err error) {
-	slog.Debug("Connecting to liquidsoap service...", "func", "liquidsoapSkip")
+func liquidsoapSkip() (string, error) {
+	slog.Debug("Connecting to Liquidsoap...", "func", "liquidsoapSkip")
 	conn, err := net.Dial("tcp", c.LiquidsoapAddress+c.LiquidsoapPort)
 	if err != nil {
-		slog.Error("Failed to connect to audio source server.", "func", "liquidsoapSkip", "error", err)
+		slog.Error("Failed to connect to Liquidsoap.", "func", "liquidsoapSkip", "error", err)
 		return "", err
 	}
 	defer conn.Close()
 	fmt.Fprintf(conn, "cadence1.skip\n")
-	// Listen for response
-	message, err = bufio.NewReader(conn).ReadString('\n')
+	msg, err := bufio.NewReader(conn).ReadString('\n')
 	if err != nil {
-		slog.Error("Failed to read stream response message from audio source server.", "func", "liquidsoapSkip", "error", err)
+		slog.Error("Failed to read Liquidsoap response.", "func", "liquidsoapSkip", "error", err)
 	}
-	slog.Debug(fmt.Sprintf("Message from audio source server: %s", message), "func", "liquidsoapSkip")
-	fmt.Fprintf(conn, "quit"+"\n")
-	return message, nil
+	fmt.Fprintf(conn, "quit\n")
+	return msg, nil
 }
 
-// Watches the music directory (CSERVER_MUSICDIR) for any changes, and reconfigures the database.
 func filesystemMonitor() {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		slog.Error("Error creating watcher.", "func", "fileSystemMonitor", "error", err)
+		slog.Error("Could not create fs watcher.", "func", "filesystemMonitor", "error", err)
 		return
 	}
 	defer watcher.Close()
-	err = watcher.Add(c.MusicDir)
-	if err != nil {
-		slog.Error("Error adding music directory to watcher.", "func", "fileSystemMonitor", "error", err)
+	if err = watcher.Add(c.MusicDir); err != nil {
+		slog.Error("Could not watch music directory.", "func", "filesystemMonitor", "error", err)
 		return
 	}
 	done := make(chan bool)
@@ -171,78 +149,89 @@ func filesystemMonitor() {
 				if !ok {
 					continue
 				}
-				slog.Info("Change detected in music library.", "func", "fileSystemMonitor")
-				err = postgresPopulate()
-				if err != nil {
-					slog.Error("Failed to populate.", "func", "fileSystemMonitor", "error", err)
-					return
+				slog.Info("Music library changed, re-indexing...", "func", "filesystemMonitor")
+				if err := postgresPopulate(); err != nil {
+					slog.Error("Re-index failed.", "func", "filesystemMonitor", "error", err)
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					continue
 				}
-				slog.Error("Error watching music library.", "func", "fileSystemMonitor", "error", err)
+				slog.Error("Watcher error.", "func", "filesystemMonitor", "error", err)
 			}
 		}
 	}()
 	<-done
 }
 
-// Watches the Icecast status page and updates stream info for SSE.
+// publicStreamURL returns the URL the browser should use to play the stream.
+// Prefers CSERVER_PUBLIC_STREAM_URL env override, falls back to Icecast host/mountpoint.
+func publicStreamURL() string {
+	if c.PublicStreamURL != "" {
+		return c.PublicStreamURL
+	}
+	if now.Host != "" && now.Host != "-" && now.Mountpoint != "" && now.Mountpoint != "-" {
+		return now.Host + "/" + now.Mountpoint
+	}
+	return ""
+}
+
 func icecastMonitor() {
-	var prev = RadioInfo{}
-	// Resets now playing, stream URL, and listener global variables to defaults. Used when Icecast is unreachable.
-	icecastDataReset := func() {
-		now.Song.Title, now.Song.Artist, now.Host, now.Mountpoint = "-", "-", "-", "-"
+	var prev RadioInfo
+	reset := func() {
+		now.Song.Title = "-"
+		now.Song.Artist = "-"
+		now.Host = "-"
+		now.Mountpoint = "-"
 		now.Listeners = -1
 	}
-	checkIcecastStatus := func() {
-		resp, err := http.Get("http://" + c.IcecastAddress + c.IcecastPort + "/status-json.xsl")
+	check := func() {
+		// c.IcecastStatusURL is already fully formed (set in main.go)
+		resp, err := http.Get(c.IcecastStatusURL)
 		if err != nil {
-			slog.Error("Unable to stream data from the Icecast service.", "func", "icecastMonitor", "error", err)
-			icecastDataReset()
+			slog.Error("Cannot reach Icecast.", "func", "icecastMonitor", "url", c.IcecastStatusURL, "error", err)
+			reset()
 			return
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			slog.Debug("Unable to connect to Icecast.", "func", "icecastMonitor")
-			icecastDataReset()
+			slog.Debug("Icecast returned non-200.", "func", "icecastMonitor", "status", resp.StatusCode)
+			reset()
 			return
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			slog.Debug("Connected to Icecast but unable to read response.", "func", "icecastMonitor")
-			icecastDataReset()
+			slog.Debug("Could not read Icecast response body.", "func", "icecastMonitor")
+			reset()
 			return
 		}
-		jsonParsed, err := gabs.ParseJSON([]byte(body))
+		json, err := gabs.ParseJSON(body)
 		if err != nil {
-			slog.Debug("Connected to Icecast but unable to parse response.", "func", "icecastMonitor")
-			icecastDataReset()
+			slog.Debug("Could not parse Icecast JSON.", "func", "icecastMonitor")
+			reset()
 			return
 		}
-		if jsonParsed.Path("icestats.source.title").Data() == nil || jsonParsed.Path("icestats.source.artist").Data() == nil {
-			slog.Debug("Connected to Icecast, but saw nothing playing.", "func", "icecastMonitor")
-			icecastDataReset()
+		if json.Path("icestats.source.title").Data() == nil || json.Path("icestats.source.artist").Data() == nil {
+			slog.Debug("Icecast connected but nothing playing.", "func", "icecastMonitor")
+			reset()
 			return
 		}
 
-		now.Song.Artist = jsonParsed.Path("icestats.source.artist").Data().(string)
-		now.Song.Title = jsonParsed.Path("icestats.source.title").Data().(string)
-		now.Host = jsonParsed.Path("icestats.host").Data().(string)
-		now.Mountpoint = jsonParsed.Path("icestats.source.server_name").Data().(string)
-		now.Listeners = jsonParsed.Path("icestats.source.listeners").Data().(float64)
-		now.Bitrate = jsonParsed.Path("icestats.source.bitrate").Data().(float64)
+		now.Song.Artist = json.Path("icestats.source.artist").Data().(string)
+		now.Song.Title = json.Path("icestats.source.title").Data().(string)
+		now.Host = json.Path("icestats.host").Data().(string)
+		now.Mountpoint = json.Path("icestats.source.server_name").Data().(string)
+		now.Listeners = json.Path("icestats.source.listeners").Data().(float64)
+		now.Bitrate = json.Path("icestats.source.bitrate").Data().(float64)
 
-		if (prev.Song.Title != now.Song.Title) || (prev.Song.Artist != now.Song.Artist) {
-			slog.Info(fmt.Sprintf("Now Playing: %s by %s", now.Song.Title, now.Song.Artist), "func", "icecastMonitor")
-			// Dump the artwork rate limiter database first thing before updates
-			// are sent out to reset artwork request count.
-			dbr.RateLimitArt.FlushDB(ctx)
-
+		if prev.Song.Title != now.Song.Title || prev.Song.Artist != now.Song.Artist {
+			slog.Info(fmt.Sprintf("Now Playing: %s - %s", now.Song.Artist, now.Song.Title), "func", "icecastMonitor")
+			if redisAvailable {
+				dbr.RateLimitArt.FlushDB(ctx)
+			}
 			radiodata_sse.SendEventMessage(now.Song.Title, "title", "")
 			radiodata_sse.SendEventMessage(now.Song.Artist, "artist", "")
-			if (prev.Song.Title != "") && (prev.Song.Artist != "") {
+			if prev.Song.Title != "" && prev.Song.Artist != "" {
 				history = append(history, playRecord{Title: prev.Song.Title, Artist: prev.Song.Artist, Ended: time.Now()})
 				if len(history) > 10 {
 					history = history[1:]
@@ -250,12 +239,12 @@ func icecastMonitor() {
 				radiodata_sse.SendEventMessage("update", "history", "")
 			}
 		}
-		if (prev.Host != now.Host) || (prev.Mountpoint != now.Mountpoint) {
-			slog.Info(fmt.Sprintf("Audio stream on: <%s/%s>", now.Host, now.Mountpoint), "func", "icecastMonitor")
-			radiodata_sse.SendEventMessage(fmt.Sprintf(now.Host, "/", now.Mountpoint), "listenurl", "")
+		if prev.Host != now.Host || prev.Mountpoint != now.Mountpoint {
+			psu := publicStreamURL()
+			slog.Info(fmt.Sprintf("Stream URL: %s", psu), "func", "icecastMonitor")
+			radiodata_sse.SendEventMessage(psu, "listenurl", "")
 		}
 		if prev.Listeners != now.Listeners {
-			slog.Info(fmt.Sprintf("Listener count: <%v>", now.Listeners), "func", "icecastMonitor")
 			radiodata_sse.SendEventMessage(fmt.Sprint(now.Listeners), "listeners", "")
 		}
 		prev = now
@@ -263,7 +252,7 @@ func icecastMonitor() {
 	go func() {
 		for {
 			time.Sleep(1 * time.Second)
-			checkIcecastStatus()
+			check()
 		}
 	}()
 }

--- a/src/server/api_actions.go
+++ b/src/server/api_actions.go
@@ -1,5 +1,5 @@
 // api_actions.go
-// API interactions for Postgres, Icecast, Liquidsoap.
+// Icecast monitor, Liquidsoap telnet, filesystem watcher.
 
 package main
 
@@ -11,13 +11,19 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Jeffail/gabs"
 	"github.com/fsnotify/fsnotify"
 )
 
-var now = RadioInfo{}
+var now     = RadioInfo{}
+var nowMu   sync.RWMutex
+
+// artCache holds base64-encoded art keyed by song path, cleared on track change.
+var artCache   sync.Map
+var artCacheKey string
 
 type RadioInfo struct {
 	Song       SongData
@@ -37,94 +43,41 @@ type SongData struct {
 	Path   string
 }
 
-func searchByQuery(query string) ([]SongData, error) {
-	query = strings.TrimSpace(query)
-	slog.Debug(fmt.Sprintf("Search query: '%s'", query), "func", "searchByQuery")
-	stmt := fmt.Sprintf(
-		"SELECT id, artist, title, album, genre, year FROM %s WHERE artist ILIKE $1 OR title ILIKE $2 ORDER BY LEAST(levenshtein($3, artist), levenshtein($4, title))",
-		c.PostgresTableName)
-	rows, err := dbp.Query(stmt, "%"+query+"%", "%"+query+"%", query, query)
-	if err != nil {
-		slog.Error("DB search failed.", "func", "searchByQuery", "error", err)
-		return nil, err
-	}
-	defer rows.Close()
-	var results []SongData
-	for rows.Next() {
-		var s SongData
-		if err = rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
-			slog.Warn("Row scan error.", "func", "searchByQuery", "error", err)
-			continue
-		}
-		results = append(results, s)
-	}
-	return results, nil
-}
-
-func searchByTitleArtist(title, artist string) ([]SongData, error) {
-	title, artist = strings.TrimSpace(title), strings.TrimSpace(artist)
-	stmt := fmt.Sprintf(
-		"SELECT id, artist, title, album, genre, year FROM %s WHERE title LIKE $1 AND artist LIKE $2",
-		c.PostgresTableName)
-	rows, err := dbp.Query(stmt, title, artist)
-	if err != nil {
-		slog.Error("DB query failed.", "func", "searchByTitleArtist", "error", err)
-		return nil, err
-	}
-	defer rows.Close()
-	var results []SongData
-	for rows.Next() {
-		var s SongData
-		if err = rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
-			slog.Warn("Row scan error.", "func", "searchByTitleArtist", "error", err)
-			continue
-		}
-		results = append(results, s)
-	}
-	return results, nil
-}
-
-func getPathById(id int) (string, error) {
-	var path string
-	stmt := fmt.Sprintf("SELECT path FROM %s WHERE id=$1", c.PostgresTableName)
-	err := dbp.QueryRow(stmt, id).Scan(&path)
-	if err != nil {
-		slog.Error("DB path lookup failed.", "func", "getPathById", "error", err)
-		return "", err
-	}
-	return path, nil
+// NowSnapshot returns a safe copy of now.
+func NowSnapshot() RadioInfo {
+	nowMu.RLock()
+	defer nowMu.RUnlock()
+	return now
 }
 
 func liquidsoapRequest(path string) (string, error) {
-	slog.Debug("Connecting to Liquidsoap...", "func", "liquidsoapRequest")
-	conn, err := net.Dial("tcp", c.LiquidsoapAddress+c.LiquidsoapPort)
+	conn, err := net.DialTimeout("tcp", c.LiquidsoapAddress+c.LiquidsoapPort, 5*time.Second)
 	if err != nil {
-		slog.Error("Failed to connect to Liquidsoap.", "func", "liquidsoapRequest", "error", err)
+		slog.Error("Liquidsoap connect failed.", "error", err)
 		return "", err
 	}
 	defer conn.Close()
 	fmt.Fprintf(conn, "request.push %s\n", path)
 	msg, err := bufio.NewReader(conn).ReadString('\n')
 	if err != nil {
-		slog.Error("Failed to read Liquidsoap response.", "func", "liquidsoapRequest", "error", err)
+		slog.Error("Liquidsoap read failed.", "error", err)
 	}
-	slog.Info(fmt.Sprintf("Liquidsoap: %s", msg), "func", "liquidsoapRequest")
 	fmt.Fprintf(conn, "quit\n")
+	slog.Info("Liquidsoap response.", "msg", strings.TrimSpace(msg))
 	return msg, nil
 }
 
 func liquidsoapSkip() (string, error) {
-	slog.Debug("Connecting to Liquidsoap...", "func", "liquidsoapSkip")
-	conn, err := net.Dial("tcp", c.LiquidsoapAddress+c.LiquidsoapPort)
+	conn, err := net.DialTimeout("tcp", c.LiquidsoapAddress+c.LiquidsoapPort, 5*time.Second)
 	if err != nil {
-		slog.Error("Failed to connect to Liquidsoap.", "func", "liquidsoapSkip", "error", err)
+		slog.Error("Liquidsoap connect failed.", "error", err)
 		return "", err
 	}
 	defer conn.Close()
 	fmt.Fprintf(conn, "cadence1.skip\n")
 	msg, err := bufio.NewReader(conn).ReadString('\n')
 	if err != nil {
-		slog.Error("Failed to read Liquidsoap response.", "func", "liquidsoapSkip", "error", err)
+		slog.Error("Liquidsoap skip read failed.", "error", err)
 	}
 	fmt.Fprintf(conn, "quit\n")
 	return msg, nil
@@ -133,128 +86,136 @@ func liquidsoapSkip() (string, error) {
 func filesystemMonitor() {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		slog.Error("Could not create fs watcher.", "func", "filesystemMonitor", "error", err)
+		slog.Error("fsnotify failed.", "error", err)
 		return
 	}
 	defer watcher.Close()
 	if err = watcher.Add(c.MusicDir); err != nil {
-		slog.Error("Could not watch music directory.", "func", "filesystemMonitor", "error", err)
+		slog.Error("Cannot watch music dir.", "error", err)
 		return
 	}
-	done := make(chan bool)
-	go func() {
-		for {
-			select {
-			case _, ok := <-watcher.Events:
-				if !ok {
-					continue
-				}
-				slog.Info("Music library changed, re-indexing...", "func", "filesystemMonitor")
-				if err := postgresPopulate(); err != nil {
-					slog.Error("Re-index failed.", "func", "filesystemMonitor", "error", err)
-				}
-			case err, ok := <-watcher.Errors:
-				if !ok {
-					continue
-				}
-				slog.Error("Watcher error.", "func", "filesystemMonitor", "error", err)
+	// Debounce: wait 3s after last event before repopulating
+	var debounce *time.Timer
+	for {
+		select {
+		case _, ok := <-watcher.Events:
+			if !ok {
+				return
 			}
+			if debounce != nil {
+				debounce.Stop()
+			}
+			debounce = time.AfterFunc(3*time.Second, func() {
+				slog.Info("Music dir changed, repopulating DB.")
+				if err := dbPopulate(); err != nil {
+					slog.Error("Repopulate failed.", "error", err)
+				}
+			})
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return
+			}
+			slog.Error("Watcher error.", "error", err)
 		}
-	}()
-	<-done
-}
-
-// publicStreamURL returns the URL the browser should use to play the stream.
-// Prefers CSERVER_PUBLIC_STREAM_URL env override, falls back to Icecast host/mountpoint.
-func publicStreamURL() string {
-	if c.PublicStreamURL != "" {
-		return c.PublicStreamURL
 	}
-	if now.Host != "" && now.Host != "-" && now.Mountpoint != "" && now.Mountpoint != "-" {
-		return now.Host + "/" + now.Mountpoint
-	}
-	return ""
 }
 
 func icecastMonitor() {
 	var prev RadioInfo
 	reset := func() {
-		now.Song.Title = "-"
-		now.Song.Artist = "-"
-		now.Host = "-"
-		now.Mountpoint = "-"
+		nowMu.Lock()
+		now.Song.Title, now.Song.Artist = "-", "-"
+		now.Host, now.Mountpoint = "-", "-"
 		now.Listeners = -1
+		nowMu.Unlock()
 	}
 	check := func() {
-		// c.IcecastStatusURL is already fully formed (set in main.go)
-		resp, err := http.Get(c.IcecastStatusURL)
+		resp, err := http.Get(c.IcecastStatusURL + "/status-json.xsl")
 		if err != nil {
-			slog.Error("Cannot reach Icecast.", "func", "icecastMonitor", "url", c.IcecastStatusURL, "error", err)
+			slog.Debug("Icecast unreachable.", "error", err)
 			reset()
 			return
 		}
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			slog.Debug("Icecast returned non-200.", "func", "icecastMonitor", "status", resp.StatusCode)
 			reset()
 			return
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			slog.Debug("Could not read Icecast response body.", "func", "icecastMonitor")
 			reset()
 			return
 		}
-		json, err := gabs.ParseJSON(body)
+		j, err := gabs.ParseJSON(body)
 		if err != nil {
-			slog.Debug("Could not parse Icecast JSON.", "func", "icecastMonitor")
 			reset()
 			return
 		}
-		if json.Path("icestats.source.title").Data() == nil || json.Path("icestats.source.artist").Data() == nil {
-			slog.Debug("Icecast connected but nothing playing.", "func", "icecastMonitor")
+		artistVal := j.Path("icestats.source.artist").Data()
+		titleVal  := j.Path("icestats.source.title").Data()
+		if artistVal == nil || titleVal == nil {
 			reset()
 			return
 		}
 
-		now.Song.Artist = json.Path("icestats.source.artist").Data().(string)
-		now.Song.Title = json.Path("icestats.source.title").Data().(string)
-		now.Host = json.Path("icestats.host").Data().(string)
-		now.Mountpoint = json.Path("icestats.source.server_name").Data().(string)
-		now.Listeners = json.Path("icestats.source.listeners").Data().(float64)
-		now.Bitrate = json.Path("icestats.source.bitrate").Data().(float64)
+		nowMu.Lock()
+		now.Song.Artist = artistVal.(string)
+		now.Song.Title  = titleVal.(string)
+		if h := j.Path("icestats.host").Data(); h != nil {
+			now.Host = h.(string)
+		}
+		if m := j.Path("icestats.source.server_name").Data(); m != nil {
+			now.Mountpoint = m.(string)
+		}
+		if l := j.Path("icestats.source.listeners").Data(); l != nil {
+			now.Listeners = l.(float64)
+		}
+		if b := j.Path("icestats.source.bitrate").Data(); b != nil {
+			now.Bitrate = b.(float64)
+		}
+		nowMu.Unlock()
 
-		if prev.Song.Title != now.Song.Title || prev.Song.Artist != now.Song.Artist {
-			slog.Info(fmt.Sprintf("Now Playing: %s - %s", now.Song.Artist, now.Song.Title), "func", "icecastMonitor")
+		nowSnap := NowSnapshot()
+
+		if prev.Song.Title != nowSnap.Song.Title || prev.Song.Artist != nowSnap.Song.Artist {
+			slog.Info("Now Playing.", "title", nowSnap.Song.Title, "artist", nowSnap.Song.Artist)
+			// Invalidate art cache
+			artCache = sync.Map{}
 			if redisAvailable {
 				dbr.RateLimitArt.FlushDB(ctx)
 			}
-			radiodata_sse.SendEventMessage(now.Song.Title, "title", "")
-			radiodata_sse.SendEventMessage(now.Song.Artist, "artist", "")
+			radiodata_sse.SendEventMessage(nowSnap.Song.Title, "title", "")
+			radiodata_sse.SendEventMessage(nowSnap.Song.Artist, "artist", "")
 			if prev.Song.Title != "" && prev.Song.Artist != "" {
-				history = append(history, playRecord{Title: prev.Song.Title, Artist: prev.Song.Artist, Ended: time.Now()})
+				history = append(history, playRecord{
+					Title:  prev.Song.Title,
+					Artist: prev.Song.Artist,
+					Ended:  time.Now(),
+				})
 				if len(history) > 10 {
 					history = history[1:]
 				}
 				radiodata_sse.SendEventMessage("update", "history", "")
 			}
 		}
-		if prev.Host != now.Host || prev.Mountpoint != now.Mountpoint {
-			psu := publicStreamURL()
-			slog.Info(fmt.Sprintf("Stream URL: %s", psu), "func", "icecastMonitor")
-			radiodata_sse.SendEventMessage(psu, "listenurl", "")
+
+		// Public stream URL: prefer CSERVER_PUBLIC_STREAM_URL, fallback to Icecast host/mountpoint
+		publicStream := c.PublicStreamURL
+		if publicStream == "" {
+			publicStream = nowSnap.Host + "/" + nowSnap.Mountpoint
 		}
-		if prev.Listeners != now.Listeners {
-			radiodata_sse.SendEventMessage(fmt.Sprint(now.Listeners), "listeners", "")
+		if prev.Host != nowSnap.Host || prev.Mountpoint != nowSnap.Mountpoint {
+			radiodata_sse.SendEventMessage(publicStream, "listenurl", "")
 		}
-		prev = now
+		if prev.Listeners != nowSnap.Listeners {
+			radiodata_sse.SendEventMessage(fmt.Sprint(nowSnap.Listeners), "listeners", "")
+		}
+		prev = nowSnap
 	}
-	go func() {
-		for {
-			time.Sleep(1 * time.Second)
-			check()
-		}
-	}()
+	for {
+		time.Sleep(1 * time.Second)
+		check()
+	}
 }
 
 var history = make([]playRecord, 0, 10)

--- a/src/server/db.go
+++ b/src/server/db.go
@@ -1,6 +1,6 @@
 // db.go
-// Backend-agnostic DB helpers. Routes calls to postgres or sqlite depending on
-// CSERVER_DB_BACKEND. All api_actions.go and api.go code uses these.
+// Backend-agnostic DB helpers. All api code uses these functions.
+// Routes calls to postgres or sqlite depending on CSERVER_DB_BACKEND.
 
 package main
 
@@ -17,16 +17,16 @@ import (
 	"github.com/dhowden/tag"
 )
 
-// dbActive points to whichever *sql.DB is in use
+// dbActive points to whichever *sql.DB is in use.
 var dbActive *sql.DB
 
-// audioExtensions supported for scanning
+// audioExtensions supported for scanning.
 var audioExtensions = map[string]bool{
 	".mp3": true, ".flac": true, ".ogg": true,
 	".m4a": true, ".opus": true, ".wav": true, ".aac": true,
 }
 
-// sanitize returns a non-empty string; falls back to `fallback`.
+// sanitize returns s trimmed; falls back to fallback if empty.
 func sanitize(s, fallback string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {
@@ -41,7 +41,7 @@ func searchByQuery(query string) ([]SongData, error) {
 	if c.DBBackend == "sqlite" {
 		return sqliteSearchByQuery(query)
 	}
-	// Postgres path with fuzzystrmatch levenshtein
+	// Postgres: fuzzystrmatch levenshtein ordering
 	sel := fmt.Sprintf(
 		`SELECT id, artist, title, album, genre, year FROM %s
 		 WHERE artist ILIKE $1 OR title ILIKE $2
@@ -110,18 +110,17 @@ func dbPopulate() error {
 		slog.Warn("CSERVER_MUSIC_DIR not set, skipping populate.")
 		return nil
 	}
-	_, err := os.Stat(c.MusicDir)
-	if err != nil {
-		slog.Error("Music directory not found.", "dir", c.MusicDir, "error", err)
+	if _, err := os.Stat(c.MusicDir); err != nil {
+		slog.Error("Music directory not accessible.", "dir", c.MusicDir, "error", err)
 		return err
 	}
 
-	// Collect files first
+	// Collect all audio files first
 	var files []string
-	err = filepath.Walk(c.MusicDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(c.MusicDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			slog.Warn("Walk error.", "path", path, "error", err)
-			return nil // don't abort walk on single file error
+			slog.Warn("Walk error, skipping path.", "path", path, "error", err)
+			return nil
 		}
 		if !info.IsDir() && audioExtensions[strings.ToLower(filepath.Ext(path))] {
 			files = append(files, path)
@@ -178,11 +177,11 @@ func dbPopulate() error {
 	return nil
 }
 
-// extractTags reads ID3/Vorbis/MP4 tags from a file.
-// Always returns usable strings even for yt-dlp downloads with minimal tags.
+// extractTags reads metadata from a file.
+// Always returns usable strings even for yt-dlp downloads with missing tags.
 func extractTags(path string) (title, album, artist, genre, year string) {
 	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-	title  = base // fallback: filename without extension
+	title  = base
 	artist = "Unknown Artist"
 	album  = "Unknown Album"
 	genre  = ""
@@ -197,8 +196,8 @@ func extractTags(path string) (title, album, artist, genre, year string) {
 
 	tags, err := tag.ReadFrom(f)
 	if err != nil {
-		// Common with yt-dlp opus/webm files - just use filename
-		slog.Debug("Tag read failed, using filename fallback.", "path", path, "error", err)
+		// Very common with yt-dlp .opus/.m4a - just use filename
+		slog.Debug("Tag read failed, using filename fallback.", "path", path)
 		return
 	}
 

--- a/src/server/db.go
+++ b/src/server/db.go
@@ -1,0 +1,213 @@
+// db.go
+// Backend-agnostic DB helpers. Routes calls to postgres or sqlite depending on
+// CSERVER_DB_BACKEND. All api_actions.go and api.go code uses these.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/dhowden/tag"
+)
+
+// dbActive points to whichever *sql.DB is in use
+var dbActive *sql.DB
+
+// audioExtensions supported for scanning
+var audioExtensions = map[string]bool{
+	".mp3": true, ".flac": true, ".ogg": true,
+	".m4a": true, ".opus": true, ".wav": true, ".aac": true,
+}
+
+// sanitize returns a non-empty string; falls back to `fallback`.
+func sanitize(s, fallback string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return fallback
+	}
+	return s
+}
+
+// searchByQuery searches the active DB for songs matching query.
+func searchByQuery(query string) ([]SongData, error) {
+	query = strings.TrimSpace(query)
+	if c.DBBackend == "sqlite" {
+		return sqliteSearchByQuery(query)
+	}
+	// Postgres path with fuzzystrmatch levenshtein
+	sel := fmt.Sprintf(
+		`SELECT id, artist, title, album, genre, year FROM %s
+		 WHERE artist ILIKE $1 OR title ILIKE $2
+		 ORDER BY LEAST(levenshtein($3, artist), levenshtein($4, title))
+		 LIMIT 200`,
+		c.PostgresTableName)
+	rows, err := dbp.Query(sel, "%"+query+"%", "%"+query+"%", query, query)
+	if err != nil {
+		slog.Error("searchByQuery failed.", "error", err)
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSongs(rows)
+}
+
+func searchByTitleArtist(title, artist string) ([]SongData, error) {
+	title  = strings.TrimSpace(title)
+	artist = strings.TrimSpace(artist)
+	if c.DBBackend == "sqlite" {
+		return sqliteSearchByTitleArtist(title, artist)
+	}
+	sel := fmt.Sprintf(
+		`SELECT id, artist, title, album, genre, year FROM %s
+		 WHERE title LIKE $1 AND artist LIKE $2 LIMIT 5`,
+		c.PostgresTableName)
+	rows, err := dbp.Query(sel, title, artist)
+	if err != nil {
+		slog.Error("searchByTitleArtist failed.", "error", err)
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSongs(rows)
+}
+
+func getPathById(id int) (string, error) {
+	table := c.PostgresTableName
+	if c.DBBackend == "sqlite" {
+		table = "metadata"
+	}
+	var path string
+	err := dbActive.QueryRow(
+		fmt.Sprintf(`SELECT path FROM %s WHERE id=$1`, table), id,
+	).Scan(&path)
+	if err == sql.ErrNoRows {
+		return "", fmt.Errorf("song id %d not found", id)
+	}
+	return path, err
+}
+
+func scanSongs(rows *sql.Rows) ([]SongData, error) {
+	var results []SongData
+	for rows.Next() {
+		var s SongData
+		if err := rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
+			slog.Warn("Row scan error, skipping.", "error", err)
+			continue
+		}
+		results = append(results, s)
+	}
+	return results, rows.Err()
+}
+
+// dbPopulate scans MusicDir with parallel workers and upserts metadata.
+func dbPopulate() error {
+	if c.MusicDir == "" {
+		slog.Warn("CSERVER_MUSIC_DIR not set, skipping populate.")
+		return nil
+	}
+	_, err := os.Stat(c.MusicDir)
+	if err != nil {
+		slog.Error("Music directory not found.", "dir", c.MusicDir, "error", err)
+		return err
+	}
+
+	// Collect files first
+	var files []string
+	err = filepath.Walk(c.MusicDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			slog.Warn("Walk error.", "path", path, "error", err)
+			return nil // don't abort walk on single file error
+		}
+		if !info.IsDir() && audioExtensions[strings.ToLower(filepath.Ext(path))] {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	workers := c.ScanWorkers
+	if workers <= 0 {
+		workers = runtime.NumCPU()
+	}
+	slog.Info(fmt.Sprintf("Scanning %d audio files with %d workers...", len(files), workers))
+
+	fileCh := make(chan string, len(files))
+	for _, f := range files {
+		fileCh <- f
+	}
+	close(fileCh)
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		scanned int
+		skipped int
+	)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for path := range fileCh {
+				title, album, artist, genre, year := extractTags(path)
+				var upsertErr error
+				if c.DBBackend == "sqlite" {
+					upsertErr = sqliteUpsert(title, album, artist, genre, year, path)
+				} else {
+					upsertErr = postgresUpsert(title, album, artist, genre, year, path)
+				}
+				mu.Lock()
+				if upsertErr != nil {
+					slog.Warn("Upsert failed, skipping.", "path", path, "error", upsertErr)
+					skipped++
+				} else {
+					scanned++
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	slog.Info(fmt.Sprintf("Scan complete: %d inserted/updated, %d skipped.", scanned, skipped))
+	return nil
+}
+
+// extractTags reads ID3/Vorbis/MP4 tags from a file.
+// Always returns usable strings even for yt-dlp downloads with minimal tags.
+func extractTags(path string) (title, album, artist, genre, year string) {
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	title  = base // fallback: filename without extension
+	artist = "Unknown Artist"
+	album  = "Unknown Album"
+	genre  = ""
+	year   = ""
+
+	f, err := os.Open(path)
+	if err != nil {
+		slog.Warn("Cannot open file for tag read.", "path", path, "error", err)
+		return
+	}
+	defer f.Close()
+
+	tags, err := tag.ReadFrom(f)
+	if err != nil {
+		// Common with yt-dlp opus/webm files - just use filename
+		slog.Debug("Tag read failed, using filename fallback.", "path", path, "error", err)
+		return
+	}
+
+	title  = sanitize(tags.Title(),  base)
+	artist = sanitize(tags.Artist(), "Unknown Artist")
+	album  = sanitize(tags.Album(),  "Unknown Album")
+	genre  = sanitize(tags.Genre(),  "")
+	if y := tags.Year(); y > 0 {
+		year = fmt.Sprintf("%d", y)
+	}
+	return
+}

--- a/src/server/db_postgres.go
+++ b/src/server/db_postgres.go
@@ -18,138 +18,163 @@ import (
 
 var dbp *sql.DB
 
-func postgresInit() (err error) {
-	// We wait a bit to give some leeway for Postgres to finish startup.
-	// Obligatory: There's probably a better way to do this.
-	time.Sleep(5 * time.Second)
-	dsn := fmt.Sprintf("host='%s' port='%s' user='%s' password='%s' sslmode='%s'",
-		c.PostgresAddress, c.PostgresPort, c.PostgresUser, c.PostgresPassword, c.PostgresSSL)
-	dbp, err = sql.Open("postgres", dsn)
-	if err != nil {
-		slog.Error("Couldn't open a connection to database.", "func", "postgresInit", "error", err)
-		return err
-	}
-	err = dbp.Ping()
-	if err != nil {
-		slog.Error("Couldn't ping the metadata database.", "func", "postgresInit", "error", err)
-		return err
-	}
-	// Enable fuzzystrmatch for levenshtein sorting.
-	// This enables the database to return results based on search similarity.
-	slog.Debug("Enabling fuzzystrmatch extension...", "func", "postgresInit")
-	enableExtension := "CREATE EXTENSION fuzzystrmatch"
-	_, err = dbp.Exec(enableExtension)
-	if err != nil {
-		if err.(*pq.Error).Code == "42710" {
-			// 42710 also indicates an existing Postgres instance configured by another Cadence instance is still running.
-			slog.Debug("fuzzystrmatch already enabled on metadata database.", "func", "postgresInit")
-		} else {
-			slog.Error("Failed to enable fuzzystrmatch. Search will function in a degraded state.", "func", "postgresInit", "error", err)
-			return err
+func postgresInit() error {
+	dsn := fmt.Sprintf("host='%s' port='%s' user='%s' password='%s' dbname='%s' sslmode='%s'",
+		c.PostgresAddress, c.PostgresPort, c.PostgresUser, c.PostgresPassword, c.PostgresDBName, c.PostgresSSL)
+
+	// Retry up to 10 times with 3s delay instead of blind sleep
+	var err error
+	for i := 1; i <= 10; i++ {
+		dbp, err = sql.Open("postgres", dsn)
+		if err != nil {
+			slog.Warn(fmt.Sprintf("DB open failed (attempt %d/10): %v", i, err), "func", "postgresInit")
+			time.Sleep(3 * time.Second)
+			continue
 		}
+		err = dbp.Ping()
+		if err != nil {
+			slog.Warn(fmt.Sprintf("DB ping failed (attempt %d/10): %v", i, err), "func", "postgresInit")
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		break
 	}
+	if err != nil {
+		slog.Error("Could not connect to Postgres after 10 attempts.", "func", "postgresInit", "error", err)
+		return err
+	}
+
+	// Enable fuzzystrmatch for levenshtein-based search ranking.
+	_, err = dbp.Exec("CREATE EXTENSION IF NOT EXISTS fuzzystrmatch")
+	if err != nil {
+		// Some managed Postgres instances block this; degrade gracefully
+		slog.Warn("Could not enable fuzzystrmatch. Fuzzy search may be degraded.", "func", "postgresInit", "error", err)
+	}
+	slog.Info("Postgres connected.", "func", "postgresInit")
 	return nil
 }
 
 func postgresPopulate() error {
-	dropDatabase := fmt.Sprintf("DROP DATABASE IF EXISTS %s", c.PostgresDBName)
-	createDatabase := fmt.Sprintf("CREATE DATABASE %s", c.PostgresDBName)
+	// Use DROP TABLE / CREATE TABLE - never DROP DATABASE.
+	// Dropping the database from within the same connection is not supported
+	// in Postgres and causes: 'ERROR: cannot drop the currently open database'.
 	dropTable := fmt.Sprintf("DROP TABLE IF EXISTS %s", c.PostgresTableName)
-	createTable := fmt.Sprintf(`CREATE TABLE %s
-	(
-	   id serial PRIMARY KEY,
-	   title character varying(255),
-	   album character varying(255),
-	   artist character varying(255),
-	   genre character varying(255),
-	   year character varying(4),
-	   path character varying(510)
-	)
-	WITH (
-	   OIDS = FALSE
-	)`, c.PostgresTableName)
+	createTable := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id     SERIAL PRIMARY KEY,
+			title  VARCHAR(255),
+			album  VARCHAR(255),
+			artist VARCHAR(255),
+			genre  VARCHAR(255),
+			year   VARCHAR(4),
+			path   VARCHAR(510)
+		)`, c.PostgresTableName)
 
-	// Drop the database and rebuild it to start fresh.
-	slog.Debug(fmt.Sprintf("Deleting existing databases named <%s>...", c.PostgresDBName), "func", "postgresPopulate")
-	_, err := dbp.Exec(dropDatabase)
-	if err != nil {
-		slog.Error("Failed to remove existing dbp. Skipping remaining autoconfig steps.", "func", "postgresPopulate", "error", err)
-		return err
-	}
-	slog.Debug(fmt.Sprintf("Creating database <%s>...", c.PostgresDBName), "func", "postgresPopulate")
-	_, err = dbp.Exec(createDatabase)
-	if err != nil {
-		slog.Error("Failed to create database. Skipping remaining autoconfig steps.", "func", "postgresPopulate", "error", err)
-		return err
-	}
 	slog.Debug(fmt.Sprintf("Dropping table <%s>...", c.PostgresTableName), "func", "postgresPopulate")
-	_, err = dbp.Exec(dropTable)
+	_, err := dbp.Exec(dropTable)
 	if err != nil {
-		slog.Error("Failed to drop table. Skipping remaining autoconfig steps.", "func", "postgresPopulate", "error", err)
+		slog.Error("Failed to drop table.", "func", "postgresPopulate", "error", err)
 		return err
 	}
+
 	slog.Debug(fmt.Sprintf("Creating table <%s>...", c.PostgresTableName), "func", "postgresPopulate")
 	_, err = dbp.Exec(createTable)
 	if err != nil {
-		if err.(*pq.Error).Code == "42P07" {
-			// 42P10 indicates an existing metadata table configured by another Cadence instance is still running.
-			slog.Info("Metadata database already exists", "func", "postgresPopulate")
+		pqErr, ok := err.(*pq.Error)
+		if ok && pqErr.Code == "42P07" {
+			slog.Info("Metadata table already exists.", "func", "postgresPopulate")
 		} else {
-			slog.Error("Failed to build database table!", "func", "postgresPopulate", "error", err)
-			return err
-		}
-	}
-	slog.Debug("Verifying music metadata directory is accessible.")
-	_, err = os.Stat(c.MusicDir)
-	if err != nil {
-		slog.Error(fmt.Sprintf("Could not open music directory <%s> for verification.", c.MusicDir), "func", postgresPopulate, "error", err)
-		if os.IsNotExist(err) {
-			slog.Error("The configured target music directory was not found.", "func", "postgresPopulate", "error", err)
+			slog.Error("Failed to create table.", "func", "postgresPopulate", "error", err)
 			return err
 		}
 	}
 
-	insertInto := fmt.Sprintf("INSERT INTO %s (%s, %s, %s, %s, %s, %s) SELECT $1, $2, $3, $4, $5, $6", c.PostgresTableName, "title", "album", "artist", "genre", "year", "path")
-	slog.Debug(fmt.Sprintf("Extracting metadata from audio files in: <%s>", c.MusicDir), "func", "postgresPopulate")
+	_, err = os.Stat(c.MusicDir)
+	if err != nil {
+		slog.Error(fmt.Sprintf("Music directory <%s> not accessible.", c.MusicDir), "func", "postgresPopulate", "error", err)
+		return err
+	}
+
+	insertInto := fmt.Sprintf(
+		"INSERT INTO %s (title, album, artist, genre, year, path) VALUES ($1, $2, $3, $4, $5, $6)",
+		c.PostgresTableName)
+
+	// Supported extensions
+	extensions := map[string]bool{
+		".mp3":  true,
+		".flac": true,
+		".ogg":  true,
+		".m4a":  true,
+		".opus": true,
+		".aac":  true,
+	}
+
+	var scanned, inserted, skipped int
+	slog.Info(fmt.Sprintf("Scanning music directory: %s", c.MusicDir), "func", "postgresPopulate")
+
 	err = filepath.Walk(c.MusicDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			slog.Error("Error during filepath walk", "func", "postgresPopulate", "error", err)
-			return err
+			slog.Warn("Walk error, skipping path.", "func", "postgresPopulate", "path", path, "error", err)
+			return nil // continue walk
 		}
-		slog.Debug(fmt.Sprintf("Populate analyzing file: <%s>", path), "func", "postgresPopulate")
 		if info.IsDir() {
-			slog.Debug(fmt.Sprintf("<%s> is a directory, skipping.", path), "func", "postgresPopulate")
 			return nil
 		}
-		extensions := []string{".mp3", ".flac", ".ogg"}
-		for _, ext := range extensions {
-			if strings.HasSuffix(path, ext) {
-				file, err := os.Open(path)
-				if err != nil {
-					slog.Error(fmt.Sprintf("Problem opening directory <%s> for music population.", path), "func", "postgresPopulate", "error", err)
-					return err
-				}
-				defer file.Close()
-				tags, err := tag.ReadFrom(file)
-				if err != nil {
-					slog.Error(fmt.Sprintf("Problem fetching tags from <%s>.", path), "func", "postgresPopulate", "error", err)
-					return err
-				}
-				_, err = dbp.Exec(insertInto, tags.Title(), tags.Album(), tags.Artist(), tags.Genre(), tags.Year(), path)
-				if err != nil {
-					slog.Error(fmt.Sprintf("Problem populating metadata for <%s>.", path), "func", "postgresPopulate", "error", err)
-					return err
-				}
-				slog.Debug(fmt.Sprintf("Finished populating track: %s by %s", tags.Title(), tags.Artist()), "func", "postgresPopulate")
-				break
+		ext := strings.ToLower(filepath.Ext(path))
+		if !extensions[ext] {
+			return nil
+		}
+		scanned++
+
+		file, err := os.Open(path)
+		if err != nil {
+			slog.Warn("Could not open file, skipping.", "func", "postgresPopulate", "path", path, "error", err)
+			skipped++
+			return nil // continue walk, do not abort
+		}
+		defer file.Close()
+
+		// Read tags - use fallback values if tags missing or corrupt
+		title, album, artist, genre, year := "", "", "", "", ""
+		tags, err := tag.ReadFrom(file)
+		if err != nil {
+			slog.Warn("Could not read tags, using filename as title.", "func", "postgresPopulate", "path", path, "error", err)
+		} else {
+			title = strings.TrimSpace(tags.Title())
+			album = strings.TrimSpace(tags.Album())
+			artist = strings.TrimSpace(tags.Artist())
+			genre = strings.TrimSpace(tags.Genre())
+			if tags.Year() > 0 {
+				year = fmt.Sprintf("%d", tags.Year())
 			}
 		}
+
+		// Fallback for empty title: use filename without extension
+		if title == "" {
+			title = strings.TrimSuffix(filepath.Base(path), ext)
+		}
+		if artist == "" {
+			artist = "Unknown Artist"
+		}
+		if album == "" {
+			album = "Unknown Album"
+		}
+
+		_, err = dbp.Exec(insertInto, title, album, artist, genre, year, path)
+		if err != nil {
+			slog.Warn("Could not insert track, skipping.", "func", "postgresPopulate", "path", path, "error", err)
+			skipped++
+			return nil // continue walk
+		}
+		inserted++
+		slog.Debug(fmt.Sprintf("Indexed: %s - %s", artist, title), "func", "postgresPopulate")
 		return nil
 	})
 	if err != nil {
-		slog.Error("Music metadata database population failed, or may be incomplete.", "func", "postgresPopulate", "error", err)
+		slog.Error("Music directory walk failed.", "func", "postgresPopulate", "error", err)
 		return err
 	}
-	slog.Info("Database population completed.", "func", "postgresPopulate")
+	slog.Info(fmt.Sprintf("Database population done. scanned=%d inserted=%d skipped=%d", scanned, inserted, skipped),
+		"func", "postgresPopulate")
 	return nil
 }

--- a/src/server/db_postgres.go
+++ b/src/server/db_postgres.go
@@ -1,5 +1,5 @@
 // db_postgres.go
-// Metadata database configuration and population.
+// Postgres metadata database. Used when CSERVER_DB_BACKEND=postgres (default).
 
 package main
 
@@ -7,58 +7,43 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 
-	"github.com/dhowden/tag"
 	"github.com/lib/pq"
+	_ "github.com/lib/pq"
 )
 
 var dbp *sql.DB
 
 func postgresInit() error {
-	dsn := fmt.Sprintf("host='%s' port='%s' user='%s' password='%s' dbname='%s' sslmode='%s'",
-		c.PostgresAddress, c.PostgresPort, c.PostgresUser, c.PostgresPassword, c.PostgresDBName, c.PostgresSSL)
-
-	// Retry up to 10 times with 3s delay instead of blind sleep
+	dsn := fmt.Sprintf(
+		"host='%s' port='%s' user='%s' password='%s' dbname='%s' sslmode='%s'",
+		c.PostgresAddress, c.PostgresPort,
+		c.PostgresUser, c.PostgresPassword,
+		c.PostgresDBName, c.PostgresSSL,
+	)
 	var err error
-	for i := 1; i <= 10; i++ {
-		dbp, err = sql.Open("postgres", dsn)
-		if err != nil {
-			slog.Warn(fmt.Sprintf("DB open failed (attempt %d/10): %v", i, err), "func", "postgresInit")
-			time.Sleep(3 * time.Second)
-			continue
-		}
-		err = dbp.Ping()
-		if err != nil {
-			slog.Warn(fmt.Sprintf("DB ping failed (attempt %d/10): %v", i, err), "func", "postgresInit")
-			time.Sleep(3 * time.Second)
-			continue
-		}
-		break
-	}
+	dbp, err = sql.Open("postgres", dsn)
 	if err != nil {
-		slog.Error("Could not connect to Postgres after 10 attempts.", "func", "postgresInit", "error", err)
+		slog.Error("Couldn't open postgres connection.", "error", err)
+		return err
+	}
+	if err = dbp.Ping(); err != nil {
+		slog.Error("Couldn't ping postgres.", "error", err)
 		return err
 	}
 
-	// Enable fuzzystrmatch for levenshtein-based search ranking.
+	// Enable fuzzystrmatch
 	_, err = dbp.Exec("CREATE EXTENSION IF NOT EXISTS fuzzystrmatch")
 	if err != nil {
-		// Some managed Postgres instances block this; degrade gracefully
-		slog.Warn("Could not enable fuzzystrmatch. Fuzzy search may be degraded.", "func", "postgresInit", "error", err)
+		// 42710 = already exists - safe to ignore
+		if pqErr, ok := err.(*pq.Error); ok && pqErr.Code == "42710" {
+			slog.Debug("fuzzystrmatch already enabled.")
+		} else {
+			slog.Warn("fuzzystrmatch enable failed; fuzzy search degraded.", "error", err)
+		}
 	}
-	slog.Info("Postgres connected.", "func", "postgresInit")
-	return nil
-}
 
-func postgresPopulate() error {
-	// Use DROP TABLE / CREATE TABLE - never DROP DATABASE.
-	// Dropping the database from within the same connection is not supported
-	// in Postgres and causes: 'ERROR: cannot drop the currently open database'.
-	dropTable := fmt.Sprintf("DROP TABLE IF EXISTS %s", c.PostgresTableName)
+	// Create table if not exists - never drop/recreate the whole DB
 	createTable := fmt.Sprintf(`
 		CREATE TABLE IF NOT EXISTS %s (
 			id     SERIAL PRIMARY KEY,
@@ -67,114 +52,25 @@ func postgresPopulate() error {
 			artist VARCHAR(255),
 			genre  VARCHAR(255),
 			year   VARCHAR(4),
-			path   VARCHAR(510)
+			path   VARCHAR(510) UNIQUE
 		)`, c.PostgresTableName)
-
-	slog.Debug(fmt.Sprintf("Dropping table <%s>...", c.PostgresTableName), "func", "postgresPopulate")
-	_, err := dbp.Exec(dropTable)
-	if err != nil {
-		slog.Error("Failed to drop table.", "func", "postgresPopulate", "error", err)
-		return err
-	}
-
-	slog.Debug(fmt.Sprintf("Creating table <%s>...", c.PostgresTableName), "func", "postgresPopulate")
 	_, err = dbp.Exec(createTable)
 	if err != nil {
-		pqErr, ok := err.(*pq.Error)
-		if ok && pqErr.Code == "42P07" {
-			slog.Info("Metadata table already exists.", "func", "postgresPopulate")
-		} else {
-			slog.Error("Failed to create table.", "func", "postgresPopulate", "error", err)
-			return err
-		}
-	}
-
-	_, err = os.Stat(c.MusicDir)
-	if err != nil {
-		slog.Error(fmt.Sprintf("Music directory <%s> not accessible.", c.MusicDir), "func", "postgresPopulate", "error", err)
+		slog.Error("Failed to create metadata table.", "error", err)
 		return err
 	}
-
-	insertInto := fmt.Sprintf(
-		"INSERT INTO %s (title, album, artist, genre, year, path) VALUES ($1, $2, $3, $4, $5, $6)",
-		c.PostgresTableName)
-
-	// Supported extensions
-	extensions := map[string]bool{
-		".mp3":  true,
-		".flac": true,
-		".ogg":  true,
-		".m4a":  true,
-		".opus": true,
-		".aac":  true,
-	}
-
-	var scanned, inserted, skipped int
-	slog.Info(fmt.Sprintf("Scanning music directory: %s", c.MusicDir), "func", "postgresPopulate")
-
-	err = filepath.Walk(c.MusicDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			slog.Warn("Walk error, skipping path.", "func", "postgresPopulate", "path", path, "error", err)
-			return nil // continue walk
-		}
-		if info.IsDir() {
-			return nil
-		}
-		ext := strings.ToLower(filepath.Ext(path))
-		if !extensions[ext] {
-			return nil
-		}
-		scanned++
-
-		file, err := os.Open(path)
-		if err != nil {
-			slog.Warn("Could not open file, skipping.", "func", "postgresPopulate", "path", path, "error", err)
-			skipped++
-			return nil // continue walk, do not abort
-		}
-		defer file.Close()
-
-		// Read tags - use fallback values if tags missing or corrupt
-		title, album, artist, genre, year := "", "", "", "", ""
-		tags, err := tag.ReadFrom(file)
-		if err != nil {
-			slog.Warn("Could not read tags, using filename as title.", "func", "postgresPopulate", "path", path, "error", err)
-		} else {
-			title = strings.TrimSpace(tags.Title())
-			album = strings.TrimSpace(tags.Album())
-			artist = strings.TrimSpace(tags.Artist())
-			genre = strings.TrimSpace(tags.Genre())
-			if tags.Year() > 0 {
-				year = fmt.Sprintf("%d", tags.Year())
-			}
-		}
-
-		// Fallback for empty title: use filename without extension
-		if title == "" {
-			title = strings.TrimSuffix(filepath.Base(path), ext)
-		}
-		if artist == "" {
-			artist = "Unknown Artist"
-		}
-		if album == "" {
-			album = "Unknown Album"
-		}
-
-		_, err = dbp.Exec(insertInto, title, album, artist, genre, year, path)
-		if err != nil {
-			slog.Warn("Could not insert track, skipping.", "func", "postgresPopulate", "path", path, "error", err)
-			skipped++
-			return nil // continue walk
-		}
-		inserted++
-		slog.Debug(fmt.Sprintf("Indexed: %s - %s", artist, title), "func", "postgresPopulate")
-		return nil
-	})
-	if err != nil {
-		slog.Error("Music directory walk failed.", "func", "postgresPopulate", "error", err)
-		return err
-	}
-	slog.Info(fmt.Sprintf("Database population done. scanned=%d inserted=%d skipped=%d", scanned, inserted, skipped),
-		"func", "postgresPopulate")
+	slog.Info("Postgres ready.", "table", c.PostgresTableName)
+	dbActive = dbp
 	return nil
+}
+
+func postgresUpsert(title, album, artist, genre, year, path string) error {
+	upsert := fmt.Sprintf(`
+		INSERT INTO %s (title, album, artist, genre, year, path)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (path) DO UPDATE
+		  SET title=$1, album=$2, artist=$3, genre=$4, year=$5`,
+		c.PostgresTableName)
+	_, err := dbp.Exec(upsert, title, album, artist, genre, year, path)
+	return err
 }

--- a/src/server/db_redis.go
+++ b/src/server/db_redis.go
@@ -1,5 +1,5 @@
 // db_redis.go
-// Rate limit database functions.
+// Rate limit database. Redis is optional - if unavailable, rate limiting is skipped.
 
 package main
 
@@ -16,6 +16,7 @@ import (
 
 var ctx = context.Background()
 var dbr = RedisClient{}
+var redisAvailable = false
 
 type RedisClient struct {
 	RateLimitRequest *redis.Client
@@ -23,112 +24,112 @@ type RedisClient struct {
 }
 
 func redisInit() {
-	dbr.RateLimitRequest = redis.NewClient(&redis.Options{
-		Addr:     c.RedisAddress + c.RedisPort,
-		Password: "",
-		DB:       0,
-	})
+	if c.RedisAddress == "" {
+		slog.Warn("CSERVER_REDISADDRESS not set. Redis rate limiting disabled.", "func", "redisInit")
+		return
+	}
+	addr := c.RedisAddress + c.RedisPort
+	opts := &redis.Options{
+		Addr:     addr,
+		Password: c.RedisPassword,
+		DB:       c.RedisDB,
+	}
+	client := redis.NewClient(opts)
+	_, err := client.Ping(ctx).Result()
+	if err != nil {
+		slog.Warn("Redis unavailable. Rate limiting disabled. Use Caddy rate_limit module as alternative.",
+			"func", "redisInit", "addr", addr, "error", err)
+		return
+	}
+	dbr.RateLimitRequest = client
 	dbr.RateLimitArt = redis.NewClient(&redis.Options{
-		Addr:     c.RedisAddress + c.RedisPort,
-		Password: "",
-		DB:       1,
+		Addr:     addr,
+		Password: c.RedisPassword,
+		DB:       c.RedisDB + 1,
 	})
+	redisAvailable = true
+	slog.Info("Redis connected.", "func", "redisInit", "addr", addr)
 }
 
 func rateLimitRequest(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !redisAvailable {
+			next.ServeHTTP(w, r)
+			return
+		}
 		ip, err := checkIP(r)
 		if err != nil {
-			slog.Error("Couldn't start IP address check for request API.", "func", "rateLimitRequest", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			slog.Error("IP check failed for request API.", "func", "rateLimitRequest", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		_, err = dbr.RateLimitRequest.Get(ctx, ip).Result()
 		if err != nil {
 			if err == redis.Nil {
-				// redis.Nil means the IP is not in the database.
-				// We create a new entry for the IP which will automatically
-				// expire after the configured rate limit time expires.
 				dbr.RateLimitRequest.Set(ctx, ip, nil, time.Duration(c.RequestRateLimit)*time.Second)
 				next.ServeHTTP(w, r)
 			} else {
-				slog.Error("Redis reported error while checking for IP.", "func", "rateLimitRequest", "error", err)
-				w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-				return
+				slog.Error("Redis error checking IP.", "func", "rateLimitRequest", "error", err)
+				// Degrade: pass through on Redis error
+				next.ServeHTTP(w, r)
 			}
 		} else {
-			slog.Info(fmt.Sprintf("IP <%s> is rate limited.", ip), "func", "rateLimitRequest")
-			w.WriteHeader(http.StatusTooManyRequests) // 429 Too Many Requests
-			return
+			slog.Info(fmt.Sprintf("IP <%s> rate limited (request).", ip), "func", "rateLimitRequest")
+			w.WriteHeader(http.StatusTooManyRequests)
 		}
 	})
 }
 
 func rateLimitArt(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !redisAvailable {
+			next.ServeHTTP(w, r)
+			return
+		}
 		ip, err := checkIP(r)
 		if err != nil {
-			slog.Error("Couldn't start IP address check for artwork API.", "func", "rateLimitArt", "error", err)
-			w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
+			slog.Error("IP check failed for art API.", "func", "rateLimitArt", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		_, err = dbr.RateLimitArt.Get(ctx, ip).Result()
 		if err != nil {
 			if err == redis.Nil {
-				// redis.Nil means the IP is not in the database.
-				// We create a new entry for the IP with start value 1,
-				// representing the first request for art.
 				dbr.RateLimitArt.Set(ctx, ip, 1, time.Duration(200)*time.Second)
 				next.ServeHTTP(w, r)
 			} else {
-				slog.Error("Redis reported error while checking for IP.", "func", "rateLimitArt", "error", err)
-				w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-				return
-			}
-		} else {
-			// If there is no error, the IP is at least in the database.
-			// Check the value of the IP address.
-			count, err := dbr.RateLimitArt.Get(ctx, ip).Int()
-			if err != nil {
-				slog.Error("Couldn't get the client's artwork request count.", "func", "rateLimitArt", "error", err)
-				w.WriteHeader(http.StatusInternalServerError) // 500 Internal Server Error
-				return
-			}
-			// We're using 16 as an arbitrary maximum number of times we expect any client to need
-			// to legitimately need to get album art over the course of a duration of one song.
-			// This strikes a balance between allowing a user to get album art when they need it
-			// and preventing malicious users from unnecessarily consuming bandwidth.
-			//
-			// Basically, a 304 response means "You've requested artwork a bit too much,
-			// so we're not going to send you new artwork for now. The artwork hasn't changed
-			// since you last asked, so you're safe to use whatever you last cached."
-			if count >= 16 {
-				slog.Info(fmt.Sprintf("IP <%s> is rate limited.", ip), "func", "rateLimitArt")
-				w.WriteHeader(http.StatusNotModified) // 304 Not Modified
-				return
-			} else {
-				slog.Info(fmt.Sprintf("IP <%s> is rate limited.", ip), "func", "rateLimitArt")
-				dbr.RateLimitArt.Set(ctx, ip, count+1, time.Duration(200)*time.Second)
+				slog.Error("Redis error checking IP.", "func", "rateLimitArt", "error", err)
 				next.ServeHTTP(w, r)
 			}
+		} else {
+			count, err := dbr.RateLimitArt.Get(ctx, ip).Int()
+			if err != nil {
+				slog.Error("Could not get art request count.", "func", "rateLimitArt", "error", err)
+				next.ServeHTTP(w, r)
+				return
+			}
+			if count >= 16 {
+				slog.Info(fmt.Sprintf("IP <%s> art rate limited.", ip), "func", "rateLimitArt")
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			dbr.RateLimitArt.Set(ctx, ip, count+1, time.Duration(200)*time.Second)
+			next.ServeHTTP(w, r)
 		}
 	})
 }
 
-func checkIP(r *http.Request) (ip string, err error) {
-	// We look at the remote address and check the IP.
-	// If for some reason no remote IP is there, we error to reject.
-	if r.RemoteAddr != "" {
-		ip, _, err := net.SplitHostPort(r.RemoteAddr)
-		if err != nil {
-			slog.Error("Couldn't split client address IP from port. The request will be rejected.", "func", "checkIP", "error", err)
-			return "", err
-		}
-		if ip == "" {
-			slog.Warn("A client IP was blank and could not be checked. The request will be rejected.", "func", "checkIP")
-			return "", err
-		}
-		return ip, nil
+func checkIP(r *http.Request) (string, error) {
+	if r.RemoteAddr == "" {
+		return "", fmt.Errorf("empty RemoteAddr")
 	}
-	return "", err
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		slog.Error("Could not split host:port from RemoteAddr.", "func", "checkIP", "error", err)
+		return "", err
+	}
+	if ip == "" {
+		return "", fmt.Errorf("blank IP in RemoteAddr")
+	}
+	return ip, nil
 }

--- a/src/server/db_redis.go
+++ b/src/server/db_redis.go
@@ -1,5 +1,6 @@
 // db_redis.go
-// Rate limit database. Redis is optional - if unavailable, rate limiting is skipped.
+// Rate limiting via Redis. Redis is optional.
+// If unavailable, rate limiting is skipped (use external tools like Caddy).
 
 package main
 
@@ -14,8 +15,8 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var ctx = context.Background()
-var dbr = RedisClient{}
+var ctx           = context.Background()
+var dbr           = RedisClient{}
 var redisAvailable = false
 
 type RedisClient struct {
@@ -24,31 +25,23 @@ type RedisClient struct {
 }
 
 func redisInit() {
-	if c.RedisAddress == "" {
-		slog.Warn("CSERVER_REDISADDRESS not set. Redis rate limiting disabled.", "func", "redisInit")
-		return
-	}
-	addr := c.RedisAddress + c.RedisPort
-	opts := &redis.Options{
-		Addr:     addr,
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     c.RedisAddress + c.RedisPort,
 		Password: c.RedisPassword,
 		DB:       c.RedisDB,
-	}
-	client := redis.NewClient(opts)
-	_, err := client.Ping(ctx).Result()
-	if err != nil {
-		slog.Warn("Redis unavailable. Rate limiting disabled. Use Caddy rate_limit module as alternative.",
-			"func", "redisInit", "addr", addr, "error", err)
+	})
+	if _, err := rdb.Ping(ctx).Result(); err != nil {
+		slog.Warn("Redis unavailable. Rate limiting disabled. Use Caddy rate_limit if needed.", "error", err)
 		return
 	}
-	dbr.RateLimitRequest = client
+	dbr.RateLimitRequest = rdb
 	dbr.RateLimitArt = redis.NewClient(&redis.Options{
-		Addr:     addr,
+		Addr:     c.RedisAddress + c.RedisPort,
 		Password: c.RedisPassword,
-		DB:       c.RedisDB + 1,
+		DB:       c.RedisDB + 1, // art uses next DB index
 	})
 	redisAvailable = true
-	slog.Info("Redis connected.", "func", "redisInit", "addr", addr)
+	slog.Info("Redis connected.", "addr", c.RedisAddress+c.RedisPort, "db", c.RedisDB)
 }
 
 func rateLimitRequest(next http.Handler) http.Handler {
@@ -59,22 +52,19 @@ func rateLimitRequest(next http.Handler) http.Handler {
 		}
 		ip, err := checkIP(r)
 		if err != nil {
-			slog.Error("IP check failed for request API.", "func", "rateLimitRequest", "error", err)
+			slog.Error("checkIP failed.", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		_, err = dbr.RateLimitRequest.Get(ctx, ip).Result()
-		if err != nil {
-			if err == redis.Nil {
-				dbr.RateLimitRequest.Set(ctx, ip, nil, time.Duration(c.RequestRateLimit)*time.Second)
-				next.ServeHTTP(w, r)
-			} else {
-				slog.Error("Redis error checking IP.", "func", "rateLimitRequest", "error", err)
-				// Degrade: pass through on Redis error
-				next.ServeHTTP(w, r)
-			}
+		if err == redis.Nil {
+			dbr.RateLimitRequest.Set(ctx, ip, 1, time.Duration(c.RequestRateLimit)*time.Second)
+			next.ServeHTTP(w, r)
+		} else if err != nil {
+			slog.Warn("Redis error in rateLimitRequest, passing through.", "error", err)
+			next.ServeHTTP(w, r)
 		} else {
-			slog.Info(fmt.Sprintf("IP <%s> rate limited (request).", ip), "func", "rateLimitRequest")
+			slog.Info(fmt.Sprintf("Rate limited: %s", ip))
 			w.WriteHeader(http.StatusTooManyRequests)
 		}
 	})
@@ -88,32 +78,24 @@ func rateLimitArt(next http.Handler) http.Handler {
 		}
 		ip, err := checkIP(r)
 		if err != nil {
-			slog.Error("IP check failed for art API.", "func", "rateLimitArt", "error", err)
+			slog.Error("checkIP failed.", "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		_, err = dbr.RateLimitArt.Get(ctx, ip).Result()
-		if err != nil {
-			if err == redis.Nil {
-				dbr.RateLimitArt.Set(ctx, ip, 1, time.Duration(200)*time.Second)
-				next.ServeHTTP(w, r)
-			} else {
-				slog.Error("Redis error checking IP.", "func", "rateLimitArt", "error", err)
-				next.ServeHTTP(w, r)
-			}
+		if err == redis.Nil {
+			dbr.RateLimitArt.Set(ctx, ip, 1, 200*time.Second)
+			next.ServeHTTP(w, r)
+		} else if err != nil {
+			slog.Warn("Redis error in rateLimitArt, passing through.", "error", err)
+			next.ServeHTTP(w, r)
 		} else {
-			count, err := dbr.RateLimitArt.Get(ctx, ip).Int()
-			if err != nil {
-				slog.Error("Could not get art request count.", "func", "rateLimitArt", "error", err)
-				next.ServeHTTP(w, r)
-				return
-			}
+			count, _ := dbr.RateLimitArt.Get(ctx, ip).Int()
 			if count >= 16 {
-				slog.Info(fmt.Sprintf("IP <%s> art rate limited.", ip), "func", "rateLimitArt")
 				w.WriteHeader(http.StatusNotModified)
 				return
 			}
-			dbr.RateLimitArt.Set(ctx, ip, count+1, time.Duration(200)*time.Second)
+			dbr.RateLimitArt.Set(ctx, ip, count+1, 200*time.Second)
 			next.ServeHTTP(w, r)
 		}
 	})
@@ -125,11 +107,10 @@ func checkIP(r *http.Request) (string, error) {
 	}
 	ip, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		slog.Error("Could not split host:port from RemoteAddr.", "func", "checkIP", "error", err)
 		return "", err
 	}
 	if ip == "" {
-		return "", fmt.Errorf("blank IP in RemoteAddr")
+		return "", fmt.Errorf("blank IP")
 	}
 	return ip, nil
 }

--- a/src/server/db_sqlite.go
+++ b/src/server/db_sqlite.go
@@ -1,0 +1,103 @@
+// db_sqlite.go
+// SQLite metadata database. Used when CSERVER_DB_BACKEND=sqlite.
+// Low-RAM alternative to Postgres. No fuzzystrmatch; uses LIKE-based search.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+var dbs *sql.DB
+
+func sqliteInit() error {
+	var err error
+	dbs, err = sql.Open("sqlite3", c.SQLitePath+"?_journal=WAL&_timeout=5000")
+	if err != nil {
+		slog.Error("Couldn't open SQLite.", "path", c.SQLitePath, "error", err)
+		return err
+	}
+	if err = dbs.Ping(); err != nil {
+		slog.Error("Couldn't ping SQLite.", "error", err)
+		return err
+	}
+	createTable := `
+		CREATE TABLE IF NOT EXISTS metadata (
+			id     INTEGER PRIMARY KEY AUTOINCREMENT,
+			title  TEXT,
+			album  TEXT,
+			artist TEXT,
+			genre  TEXT,
+			year   TEXT,
+			path   TEXT UNIQUE
+		)`
+	_, err = dbs.Exec(createTable)
+	if err != nil {
+		slog.Error("Failed to create SQLite table.", "error", err)
+		return err
+	}
+	slog.Info("SQLite ready.", "path", c.SQLitePath)
+	dbActive = dbs
+	return nil
+}
+
+func sqliteUpsert(title, album, artist, genre, year, path string) error {
+	upsert := `
+		INSERT INTO metadata (title, album, artist, genre, year, path)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(path) DO UPDATE
+		  SET title=excluded.title, album=excluded.album,
+		      artist=excluded.artist, genre=excluded.genre, year=excluded.year`
+	_, err := dbs.Exec(upsert, title, album, artist, genre, year, path)
+	return err
+}
+
+// SQLite levenshtein fallback: ORDER BY instr() similarity (no extension needed)
+func sqliteSearchByQuery(query string) ([]SongData, error) {
+	rows, err := dbs.Query(`
+		SELECT id, artist, title, album, genre, year FROM metadata
+		WHERE artist LIKE ? OR title LIKE ?
+		ORDER BY
+		  CASE WHEN title LIKE ? THEN 0 ELSE 1 END,
+		  CASE WHEN artist LIKE ? THEN 0 ELSE 1 END
+		LIMIT 200`,
+		"%"+query+"%", "%"+query+"%", query+"%", query+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var results []SongData
+	for rows.Next() {
+		var s SongData
+		if err := rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
+			continue
+		}
+		results = append(results, s)
+	}
+	return results, nil
+}
+
+func sqliteSearchByTitleArtist(title, artist string) ([]SongData, error) {
+	rows, err := dbs.Query(
+		`SELECT id, artist, title, album, genre, year FROM metadata WHERE title=? AND artist=? LIMIT 5`,
+		title, artist)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var results []SongData
+	for rows.Next() {
+		var s SongData
+		if err := rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
+			continue
+		}
+		results = append(results, s)
+	}
+	return results, nil
+}
+
+func fmt_unused() { _ = fmt.Sprintf }

--- a/src/server/db_sqlite.go
+++ b/src/server/db_sqlite.go
@@ -1,22 +1,21 @@
 // db_sqlite.go
 // SQLite metadata database. Used when CSERVER_DB_BACKEND=sqlite.
-// Low-RAM alternative to Postgres. No fuzzystrmatch; uses LIKE-based search.
+// Uses modernc.org/sqlite (pure Go, no CGO required).
 
 package main
 
 import (
 	"database/sql"
-	"fmt"
 	"log/slog"
 
-	_ "github.com/mattn/go-sqlite3"
+	_ "modernc.org/sqlite"
 )
 
 var dbs *sql.DB
 
 func sqliteInit() error {
 	var err error
-	dbs, err = sql.Open("sqlite3", c.SQLitePath+"?_journal=WAL&_timeout=5000")
+	dbs, err = sql.Open("sqlite", c.SQLitePath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		slog.Error("Couldn't open SQLite.", "path", c.SQLitePath, "error", err)
 		return err
@@ -25,7 +24,7 @@ func sqliteInit() error {
 		slog.Error("Couldn't ping SQLite.", "error", err)
 		return err
 	}
-	createTable := `
+	_, err = dbs.Exec(`
 		CREATE TABLE IF NOT EXISTS metadata (
 			id     INTEGER PRIMARY KEY AUTOINCREMENT,
 			title  TEXT,
@@ -34,10 +33,9 @@ func sqliteInit() error {
 			genre  TEXT,
 			year   TEXT,
 			path   TEXT UNIQUE
-		)`
-	_, err = dbs.Exec(createTable)
+		)`)
 	if err != nil {
-		slog.Error("Failed to create SQLite table.", "error", err)
+		slog.Error("Failed to create SQLite metadata table.", "error", err)
 		return err
 	}
 	slog.Info("SQLite ready.", "path", c.SQLitePath)
@@ -46,23 +44,22 @@ func sqliteInit() error {
 }
 
 func sqliteUpsert(title, album, artist, genre, year, path string) error {
-	upsert := `
+	_, err := dbs.Exec(`
 		INSERT INTO metadata (title, album, artist, genre, year, path)
 		VALUES (?, ?, ?, ?, ?, ?)
 		ON CONFLICT(path) DO UPDATE
 		  SET title=excluded.title, album=excluded.album,
-		      artist=excluded.artist, genre=excluded.genre, year=excluded.year`
-	_, err := dbs.Exec(upsert, title, album, artist, genre, year, path)
+		      artist=excluded.artist, genre=excluded.genre, year=excluded.year`,
+		title, album, artist, genre, year, path)
 	return err
 }
 
-// SQLite levenshtein fallback: ORDER BY instr() similarity (no extension needed)
 func sqliteSearchByQuery(query string) ([]SongData, error) {
 	rows, err := dbs.Query(`
 		SELECT id, artist, title, album, genre, year FROM metadata
 		WHERE artist LIKE ? OR title LIKE ?
 		ORDER BY
-		  CASE WHEN title LIKE ? THEN 0 ELSE 1 END,
+		  CASE WHEN title  LIKE ? THEN 0 ELSE 1 END,
 		  CASE WHEN artist LIKE ? THEN 0 ELSE 1 END
 		LIMIT 200`,
 		"%"+query+"%", "%"+query+"%", query+"%", query+"%")
@@ -70,15 +67,7 @@ func sqliteSearchByQuery(query string) ([]SongData, error) {
 		return nil, err
 	}
 	defer rows.Close()
-	var results []SongData
-	for rows.Next() {
-		var s SongData
-		if err := rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
-			continue
-		}
-		results = append(results, s)
-	}
-	return results, nil
+	return scanSongRows(rows)
 }
 
 func sqliteSearchByTitleArtist(title, artist string) ([]SongData, error) {
@@ -89,15 +78,18 @@ func sqliteSearchByTitleArtist(title, artist string) ([]SongData, error) {
 		return nil, err
 	}
 	defer rows.Close()
+	return scanSongRows(rows)
+}
+
+func scanSongRows(rows *sql.Rows) ([]SongData, error) {
 	var results []SongData
 	for rows.Next() {
 		var s SongData
 		if err := rows.Scan(&s.ID, &s.Artist, &s.Title, &s.Album, &s.Genre, &s.Year); err != nil {
+			slog.Warn("Row scan error, skipping.", "error", err)
 			continue
 		}
 		results = append(results, s)
 	}
-	return results, nil
+	return results, rows.Err()
 }
-
-func fmt_unused() { _ = fmt.Sprintf }

--- a/src/server/go.mod
+++ b/src/server/go.mod
@@ -7,13 +7,16 @@ require (
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/lib/pq v1.10.9
-	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/redis/go-redis/v9 v9.5.1
 	gopkg.in/antage/eventsource.v1 v1.0.0-20150318155416-803f4c5af225
+	modernc.org/sqlite v1.31.1
 )
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	golang.org/x/sys v0.20.0 // indirect
+	modernc.org/libc v1.55.3 // indirect
+	modernc.org/mathutil v1.6.0 // indirect
+	modernc.org/memory v1.8.0 // indirect
 )

--- a/src/server/go.mod
+++ b/src/server/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/lib/pq v1.10.9
+	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/redis/go-redis/v9 v9.5.1
 	gopkg.in/antage/eventsource.v1 v1.0.0-20150318155416-803f4c5af225
 )

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -19,8 +19,10 @@ type ServerConfig struct {
 	MusicDir          string
 	LiquidsoapAddress string
 	LiquidsoapPort    string
-	IcecastAddress    string
-	IcecastPort       string
+	// Internal address cadence uses to poll Icecast status (server-side, Docker network)
+	IcecastStatusURL  string
+	// Public stream URL sent to browser clients (e.g. https://radio.example.com/stream)
+	PublicStreamURL   string
 	PostgresAddress   string
 	PostgresPort      string
 	PostgresUser      string
@@ -30,6 +32,8 @@ type ServerConfig struct {
 	PostgresSSL       string
 	RedisAddress      string
 	RedisPort         string
+	RedisPassword     string
+	RedisDB           int
 	WhitelistPath     string
 	DevMode           bool
 	LogLevel          string
@@ -39,7 +43,6 @@ func parseLogLevel(level string) slog.Level {
 	if level == "" {
 		return slog.LevelInfo
 	}
-
 	switch strings.ToLower(level) {
 	case "debug":
 		return slog.LevelDebug
@@ -50,9 +53,22 @@ func parseLogLevel(level string) slog.Level {
 	case "error":
 		return slog.LevelError
 	default:
-		slog.Warn(fmt.Sprintf("Unrecognized log level %s!", level), "func", "parseLogLevel")
+		slog.Warn(fmt.Sprintf("Unrecognized log level '%s', defaulting to info.", level), "func", "parseLogLevel")
 		return slog.LevelInfo
 	}
+}
+
+// stripScheme removes http:// or https:// from an address string.
+// Cadence always prepends http:// internally for Icecast polling.
+func stripScheme(addr string) string {
+	for _, prefix := range []string{"https://", "http://"} {
+		if strings.HasPrefix(addr, prefix) {
+			slog.Warn(fmt.Sprintf("Scheme prefix found in address '%s' - stripping. Use host:port format.", addr),
+				"func", "stripScheme")
+			return strings.TrimPrefix(addr, prefix)
+		}
+	}
+	return addr
 }
 
 func main() {
@@ -63,8 +79,19 @@ func main() {
 	c.MusicDir = os.Getenv("CSERVER_MUSIC_DIR")
 	c.LiquidsoapAddress = os.Getenv("CSERVER_LIQUIDSOAPADDRESS")
 	c.LiquidsoapPort = os.Getenv("CSERVER_LIQUIDSOAPPORT")
-	c.IcecastAddress = os.Getenv("CSERVER_ICECASTADDRESS")
-	c.IcecastPort = os.Getenv("CSERVER_ICECASTPORT")
+
+	// Internal Icecast status URL (server-to-server, Docker network)
+	// Defaults to http://icecast2:8000 if not set
+	icecastHost := stripScheme(os.Getenv("CSERVER_ICECASTADDRESS"))
+	if icecastHost == "" {
+		icecastHost = "icecast2:8000"
+	}
+	c.IcecastStatusURL = "http://" + icecastHost + "/status-json.xsl"
+
+	// Public stream URL for browser audio element
+	// If not set, falls back to the Icecast host (original behavior)
+	c.PublicStreamURL = os.Getenv("CSERVER_PUBLIC_STREAM_URL")
+
 	c.PostgresAddress = os.Getenv("CSERVER_POSTGRESADDRESS")
 	c.PostgresPort = os.Getenv("CSERVER_POSTGRESPORT")
 	c.PostgresUser = os.Getenv("CSERVER_POSTGRESUSER")
@@ -74,11 +101,19 @@ func main() {
 	c.PostgresSSL = os.Getenv("CSERVER_POSTGRESSSL")
 	c.RedisAddress = os.Getenv("CSERVER_REDISADDRESS")
 	c.RedisPort = os.Getenv("CSERVER_REDISPORT")
+	c.RedisPassword = os.Getenv("CSERVER_REDISPASSWORD")
+	c.RedisDB, _ = strconv.Atoi(os.Getenv("CSERVER_REDISDB"))
 	c.WhitelistPath = os.Getenv("CSERVER_WHITELIST_PATH")
 	c.DevMode, _ = strconv.ParseBool(os.Getenv("CSERVER_DEVMODE"))
 	c.LogLevel = os.Getenv("CSERVER_LOGLEVEL")
 
 	slog.SetLogLoggerLevel(parseLogLevel(c.LogLevel))
+
+	slog.Info("Starting Cadence (homelab build).", "version", c.Version)
+	slog.Info(fmt.Sprintf("Icecast status URL: %s", c.IcecastStatusURL))
+	if c.PublicStreamURL != "" {
+		slog.Info(fmt.Sprintf("Public stream URL override: %s", c.PublicStreamURL))
+	}
 
 	if postgresInit() == nil {
 		if postgresPopulate() != nil {
@@ -89,8 +124,8 @@ func main() {
 	go filesystemMonitor()
 	go icecastMonitor()
 
-	slog.Info(fmt.Sprintf("Starting Cadence on port <%s>.", c.Port), "func", "main")
-	if http.ListenAndServe(c.Port, routes()) != nil {
-		slog.Error("Cadence failed to start!", "func", "main")
+	slog.Info(fmt.Sprintf("Listening on port %s.", c.Port), "func", "main")
+	if err := http.ListenAndServe(c.Port, routes()); err != nil {
+		slog.Error("Cadence failed to start!", "func", "main", "error", err)
 	}
 }

--- a/src/server/main.go
+++ b/src/server/main.go
@@ -19,10 +19,11 @@ type ServerConfig struct {
 	MusicDir          string
 	LiquidsoapAddress string
 	LiquidsoapPort    string
-	// Internal address cadence uses to poll Icecast status (server-side, Docker network)
+	// Internal status endpoint (Docker hostname, never leaves the network)
 	IcecastStatusURL  string
-	// Public stream URL sent to browser clients (e.g. https://radio.example.com/stream)
+	// Public stream URL sent to the browser
 	PublicStreamURL   string
+	DBBackend         string // "postgres" or "sqlite"
 	PostgresAddress   string
 	PostgresPort      string
 	PostgresUser      string
@@ -30,6 +31,7 @@ type ServerConfig struct {
 	PostgresDBName    string
 	PostgresTableName string
 	PostgresSSL       string
+	SQLitePath        string
 	RedisAddress      string
 	RedisPort         string
 	RedisPassword     string
@@ -37,95 +39,109 @@ type ServerConfig struct {
 	WhitelistPath     string
 	DevMode           bool
 	LogLevel          string
+	ScanWorkers       int
 }
 
 func parseLogLevel(level string) slog.Level {
-	if level == "" {
-		return slog.LevelInfo
-	}
 	switch strings.ToLower(level) {
 	case "debug":
 		return slog.LevelDebug
-	case "info":
-		return slog.LevelInfo
 	case "warn":
 		return slog.LevelWarn
 	case "error":
 		return slog.LevelError
 	default:
-		slog.Warn(fmt.Sprintf("Unrecognized log level '%s', defaulting to info.", level), "func", "parseLogLevel")
 		return slog.LevelInfo
 	}
 }
 
-// stripScheme removes http:// or https:// from an address string.
-// Cadence always prepends http:// internally for Icecast polling.
+// stripScheme removes http:// or https:// from addresses that must be host-only.
 func stripScheme(addr string) string {
 	for _, prefix := range []string{"https://", "http://"} {
 		if strings.HasPrefix(addr, prefix) {
-			slog.Warn(fmt.Sprintf("Scheme prefix found in address '%s' - stripping. Use host:port format.", addr),
-				"func", "stripScheme")
+			slog.Warn(fmt.Sprintf("Scheme prefix found in '%s', stripping. Use host:port format.", addr))
 			return strings.TrimPrefix(addr, prefix)
 		}
 	}
 	return addr
 }
 
-func main() {
-	c.Version = os.Getenv("CSERVER_VERSION")
-	c.RootPath = os.Getenv("CSERVER_ROOTPATH")
-	c.RequestRateLimit, _ = strconv.Atoi(os.Getenv("CSERVER_REQRATELIMIT"))
-	c.Port = os.Getenv("CSERVER_PORT")
-	c.MusicDir = os.Getenv("CSERVER_MUSIC_DIR")
-	c.LiquidsoapAddress = os.Getenv("CSERVER_LIQUIDSOAPADDRESS")
-	c.LiquidsoapPort = os.Getenv("CSERVER_LIQUIDSOAPPORT")
-
-	// Internal Icecast status URL (server-to-server, Docker network)
-	// Defaults to http://icecast2:8000 if not set
-	icecastHost := stripScheme(os.Getenv("CSERVER_ICECASTADDRESS"))
-	if icecastHost == "" {
-		icecastHost = "icecast2:8000"
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
 	}
-	c.IcecastStatusURL = "http://" + icecastHost + "/status-json.xsl"
+	return def
+}
 
-	// Public stream URL for browser audio element
-	// If not set, falls back to the Icecast host (original behavior)
-	c.PublicStreamURL = os.Getenv("CSERVER_PUBLIC_STREAM_URL")
+func main() {
+	c.Version           = envOrDefault("CSERVER_VERSION", "dev")
+	c.RootPath          = envOrDefault("CSERVER_ROOTPATH", "/cadence/server/")
+	c.RequestRateLimit, _ = strconv.Atoi(envOrDefault("CSERVER_REQRATELIMIT", "5"))
+	c.Port              = envOrDefault("CSERVER_PORT", ":8080")
+	c.MusicDir          = os.Getenv("CSERVER_MUSIC_DIR")
+	c.LiquidsoapAddress = stripScheme(envOrDefault("CSERVER_LIQUIDSOAPADDRESS", "liquidsoap"))
+	c.LiquidsoapPort    = envOrDefault("CSERVER_LIQUIDSOAPPORT", ":1234")
 
-	c.PostgresAddress = os.Getenv("CSERVER_POSTGRESADDRESS")
-	c.PostgresPort = os.Getenv("CSERVER_POSTGRESPORT")
-	c.PostgresUser = os.Getenv("CSERVER_POSTGRESUSER")
-	c.PostgresPassword = os.Getenv("POSTGRES_PASSWORD")
-	c.PostgresDBName = os.Getenv("CSERVER_POSTGRESDBNAME")
-	c.PostgresTableName = os.Getenv("CSERVER_POSTGRESTABLENAME")
-	c.PostgresSSL = os.Getenv("CSERVER_POSTGRESSSL")
-	c.RedisAddress = os.Getenv("CSERVER_REDISADDRESS")
-	c.RedisPort = os.Getenv("CSERVER_REDISPORT")
-	c.RedisPassword = os.Getenv("CSERVER_REDISPASSWORD")
-	c.RedisDB, _ = strconv.Atoi(os.Getenv("CSERVER_REDISDB"))
-	c.WhitelistPath = os.Getenv("CSERVER_WHITELIST_PATH")
-	c.DevMode, _ = strconv.ParseBool(os.Getenv("CSERVER_DEVMODE"))
-	c.LogLevel = os.Getenv("CSERVER_LOGLEVEL")
+	// Internal Icecast status URL (used only by server, never forwarded to client)
+	c.IcecastStatusURL  = envOrDefault("CSERVER_ICECAST_STATUS_URL", "http://icecast2:8000")
+	// Trim trailing slash
+	c.IcecastStatusURL  = strings.TrimRight(c.IcecastStatusURL, "/")
+	// Public stream URL sent to browser - defaults to same as status host but can differ
+	c.PublicStreamURL   = os.Getenv("CSERVER_PUBLIC_STREAM_URL")
+
+	c.DBBackend         = strings.ToLower(envOrDefault("CSERVER_DB_BACKEND", "postgres"))
+	c.PostgresAddress   = stripScheme(envOrDefault("CSERVER_POSTGRESADDRESS", "postgres"))
+	c.PostgresPort      = envOrDefault("CSERVER_POSTGRESPORT", "5432")
+	c.PostgresUser      = envOrDefault("CSERVER_POSTGRESUSER", "postgres")
+	c.PostgresPassword  = os.Getenv("POSTGRES_PASSWORD")
+	c.PostgresDBName    = envOrDefault("CSERVER_POSTGRESDBNAME", "cadence")
+	c.PostgresTableName = envOrDefault("CSERVER_POSTGRESTABLENAME", "metadata")
+	c.PostgresSSL       = envOrDefault("CSERVER_POSTGRESSSL", "disable")
+	c.SQLitePath        = envOrDefault("CSERVER_SQLITE_PATH", "/data/cadence.db")
+
+	c.RedisAddress      = stripScheme(envOrDefault("CSERVER_REDISADDRESS", "redis"))
+	c.RedisPort         = envOrDefault("CSERVER_REDISPORT", ":6379")
+	c.RedisPassword     = os.Getenv("CSERVER_REDISPASSWORD")
+	c.RedisDB, _        = strconv.Atoi(envOrDefault("CSERVER_REDISDB", "0"))
+
+	c.WhitelistPath     = os.Getenv("CSERVER_WHITELIST_PATH")
+	c.DevMode, _        = strconv.ParseBool(os.Getenv("CSERVER_DEVMODE"))
+	c.LogLevel          = envOrDefault("CSERVER_LOGLEVEL", "info")
+	c.ScanWorkers, _    = strconv.Atoi(envOrDefault("CSERVER_SCAN_WORKERS", "4"))
 
 	slog.SetLogLoggerLevel(parseLogLevel(c.LogLevel))
 
-	slog.Info("Starting Cadence (homelab build).", "version", c.Version)
-	slog.Info(fmt.Sprintf("Icecast status URL: %s", c.IcecastStatusURL))
-	if c.PublicStreamURL != "" {
-		slog.Info(fmt.Sprintf("Public stream URL override: %s", c.PublicStreamURL))
+	// Validate required config
+	if c.MusicDir == "" {
+		slog.Warn("CSERVER_MUSIC_DIR is not set; database will not be populated.")
 	}
 
-	if postgresInit() == nil {
-		if postgresPopulate() != nil {
-			slog.Warn("Initial database population failed.", "func", "main")
+	// Init DB backend
+	switch c.DBBackend {
+	case "sqlite":
+		if err := sqliteInit(); err != nil {
+			slog.Warn("SQLite init failed.", "error", err)
+		} else {
+			if err := dbPopulate(); err != nil {
+				slog.Warn("Initial DB population failed.", "error", err)
+			}
+		}
+	default: // postgres
+		if err := postgresInit(); err != nil {
+			slog.Warn("Postgres init failed.", "error", err)
+		} else {
+			if err := dbPopulate(); err != nil {
+				slog.Warn("Initial DB population failed.", "error", err)
+			}
 		}
 	}
+
 	go redisInit()
 	go filesystemMonitor()
 	go icecastMonitor()
 
-	slog.Info(fmt.Sprintf("Listening on port %s.", c.Port), "func", "main")
+	slog.Info(fmt.Sprintf("Starting Cadence %s on %s [db=%s]", c.Version, c.Port, c.DBBackend))
 	if err := http.ListenAndServe(c.Port, routes()); err != nil {
-		slog.Error("Cadence failed to start!", "func", "main", "error", err)
+		slog.Error("Cadence failed to start!", "error", err)
 	}
 }

--- a/src/server/public/css/custom.css
+++ b/src/server/public/css/custom.css
@@ -1,0 +1,13 @@
+/* custom.css
+ * This file is mounted from the host via Docker volume.
+ * Override any style here without rebuilding the image.
+ *
+ * Example: change accent color
+ *   :root { --accent: hotpink; }
+ *
+ * Example: hide the version line
+ *   #version { display: none; }
+ *
+ * Example: bigger artwork
+ *   :root { --art-size: 320px; }
+ */

--- a/src/server/public/css/main.css
+++ b/src/server/public/css/main.css
@@ -1,128 +1,147 @@
-body {
-	font-family: "Roboto Condensed", sans-serif;
-	padding-left: 5%;
-	padding-right: 5%;
+/* main.css - Base styles. Override with custom.css (mounted volume). */
+
+:root {
+  --bg: #fff;
+  --fg: #212529;
+  --card-bg: #f8f8f8;
+  --border: #aaa;
+  --art-size: min(50vw, 240px);
 }
 
-footer {
-	font-size: 90%;
-	max-width: 320px;
-    text-align: center;
-    margin-top: 50px;
-    margin-bottom: 30px;
-	margin-left: auto;
-	margin-right: auto;
+[data-theme="dark"] {
+  --bg: #0d0d0d;
+  --fg: #e8e8e8;
+  --card-bg: #1a1a1a;
+  --border: #444;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+  margin: 0;
+  padding: 0;
+  transition: background 0.2s, color 0.2s;
+}
+
+body {
+  padding: 16px;
+  max-width: 860px;
+  margin: 0 auto;
 }
 
 #player {
-	margin-top: 2%;
-	text-align: center;
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
 }
 
 #artworkcontainer {
-	margin: 0 auto;
-	border: 1px solid black;
-	width: 50vw;
-	height: 50vw;
-	max-width: 240px;
-	max-height: 240px;
+  flex-shrink: 0;
+  width: var(--art-size);
+  height: var(--art-size);
+  border: 3px solid var(--border);
+  background: var(--card-bg);
+  overflow: hidden;
 }
 
-#player #song {
-	font-size: 24px;
+#artwork {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
-#player #artist {
-	font-size: 21px;
+#playerinfo {
+  flex: 1;
+  min-width: 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
-#player #playButton {
-	border: 1px solid black;
-	font-size: 20px;
-	text-align: center;
-	padding: 11px;
-	width: 80px;
-	height: 45px;
-	border-radius: 10%;
-	cursor: pointer;
-	margin-top: 20px;
-	margin-bottom: 20px;
-	margin-left: auto;
-	margin-right: auto;
-	line-height: 100%;
+#song   { font-size: 1.2em; line-height: 1.6; }
+#artist { font-size: 1.0em; }
+
+#playButton {
+  cursor: pointer;
+  width: 80px;
+  text-align: center;
 }
 
-#player #status,
-#player #version {
-	font-size: 14px;
+#volumerow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-#searchResults tr, #historyResults tr {
-	max-height: 100%;
+#volume { flex: 1; }
+
+#status, #version { font-size: 0.75em; opacity: 0.8; }
+
+#controls {
+  margin: 12px 0;
+  text-align: right;
 }
 
-#searchResults tr th, #searchResults tr td, #historyResults tr th, #historyResults tr td{
-	text-align: left;
-	margin-top: auto;
-	vertical-align: center;
-	font-size: 17px;
+#tabs ul {
+  display: flex;
+  gap: 8px;
+  padding: 0;
+  list-style: none;
+  margin: 16px 0 8px;
 }
 
-#tab-content section {
-    display: none;
-}
-#tab-content section.is-active {
-    display: block;
-}
+#tab-content section { display: none; }
+#tab-content section.is-active { display: block; }
 
+.nes-field { margin: 8px 0; }
 
-#requestStatus, #historyStatus {
-	text-align: center;
-	margin-top: 5px;
-	margin-bottom: 5px;
+#searchResults, #historyResults {
+  margin-top: 8px;
 }
 
-@media (min-width: 769px) {
-	body {
-		padding-left: 16%;
-		padding-right: 16%;
-	}
-
-	#playerinfo {
-		text-align: left;
-	}
-
-	#player #playButton {
-		margin-left: 0;
-		margin-right: 0;
-	}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85em;
+}
+th, td {
+  text-align: left;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
 }
 
-@media (min-width: 1200px) {
-	body {
-		padding-left: 23%;
-		padding-right: 23%;
-	}
+footer {
+  margin-top: 32px;
+  padding: 16px;
+  font-size: 0.75em;
+  display: flex;
+  justify-content: space-between;
+  border-top: 2px solid var(--border);
 }
 
-@media (min-width: 1600px) {
-	body {
-		padding-left: 26%;
-		padding-right: 26%;
-	}
+/* NES.css dark overrides */
+[data-theme="dark"] .nes-container {
+  background: var(--card-bg);
+  color: var(--fg);
 }
-
-@media (min-width: 1800px) {
-	body {
-		padding-left: 29%;
-		padding-right: 29%;
-	}
-
-	#player #song {
-		font-size: 28px;
-	}
-
-	#player #artist {
-		font-size: 25px;
-	}
+[data-theme="dark"] .nes-container::before,
+[data-theme="dark"] .nes-container::after,
+[data-theme="dark"] .nes-container > .title::before,
+[data-theme="dark"] .nes-container > .title::after {
+  background-color: var(--card-bg);
+}
+[data-theme="dark"] .nes-input,
+[data-theme="dark"] .nes-textarea {
+  background: #111;
+  color: #e8e8e8;
+}
+[data-theme="dark"] .nes-btn {
+  background: #222;
+  color: #e8e8e8;
 }

--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -1,78 +1,78 @@
 <!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="UTF-8"/>
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cadence Radio</title>
+  <meta name="description" content="Self-hosted web radio">
 
-		<title>Cadence | Open-Source Self Hosted Web Radio</title>
-		<meta name="title" content="Cadence | Open-Source Self Hosted Web Radio">
-		<meta name="description" content="Start a web radio website in minutes.">
-		<meta property="og:type" content="website">
-		<meta property="og:url" content="https://cadenceradio.com/">
-		<meta property="og:title" content="Cadence | Open-Source Self Hosted Web Radio">
-		<meta property="og:description" content="Start a web radio website in minutes.">
-		<meta property="og:image" content="/static/splash.jpg">
-		<meta property="twitter:card" content="summary_large_image">
-		<meta property="twitter:url" content="https://cadenceradio.com/">
-		<meta property="twitter:title" content="Cadence | Open-Source Self Hosted Web Radio">
-		<meta property="twitter:description" content="Start a web radio website in minutes.">
-		<meta property="twitter:image" content="/static/splash.jpg">
+  <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
 
-		<link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+  <!-- NES.css -->
+  <link href="https://unpkg.com/nes.css@2.3.0/css/nes.min.css" rel="stylesheet">
+  <!-- Google Fonts for NES.css -->
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+  <!-- Base styles -->
+  <link rel="stylesheet" href="./css/main.css">
+  <!-- User customisation (mounted volume) - loaded last to override everything -->
+  <link rel="stylesheet" href="./css/custom.css" onerror="this.remove()">
+</head>
+<body>
 
-		<link rel="preconnect" href="https://fonts.googleapis.com">
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300&display=swap" rel="stylesheet"> 
+<main id="app">
+  <div id="player" class="nes-container with-title is-centered">
+    <p class="title">Now Playing</p>
+    <div id="artworkcontainer">
+      <img id="artwork" src="./static/blank.jpg" alt="Album Art"/>
+    </div>
+    <div id="playerinfo">
+      <audio id="stream" src="" type="audio/mp3"></audio>
+      <div id="song" class="nes-text">-</div>
+      <div id="artist" class="nes-text is-primary">-</div>
+      <div id="playButton" class="nes-btn is-primary">&#9654;</div>
+      <div id="volumerow">
+        <span class="nes-text">Vol</span>
+        <input type="range" id="volume" class="nes-progress" value=".3" min="0" max="1" step="0.006">
+      </div>
+      <div id="status" class="nes-text is-disabled">Connecting...</div>
+      <div id="version">Listeners: <span id="listeners">-</span></div>
+    </div>
+  </div>
 
-		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
-		<link rel="stylesheet" href="./css/main.css">
+  <div id="controls">
+    <button id="themeToggle" class="nes-btn">&#9790; Dark / &#9788; Light</button>
+  </div>
 
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script type="text/javascript" src="./js/aria.js"></script>
-        <script type="text/javascript" src="./js/page.js"></script>
-    </head>
-    <body>
-        <div id="player" class="columns is-centered is-vcentered box is-rounded">
-            <div class="column is-narrow is-offset-1-desktop is-3-desktop-only">
-                <div id="artworkcontainer">
-                    <img id="artwork" src="./static/blank.jpg"/>
-                </div>
-            </div>
-            <div class="column" id="playerinfo">
-                <audio id="stream" src="" type="audio/mp3"></audio>
-                <div id="song">-</div>
-                <div id="artist">-</div>
-                <div id="playButton">►</div>
-                <input type="range" id="volume" value=".3" min="0" max="1" step="0.006" class="block" >
-                <div id="status">Disconnected from server.</div>
-                <div id="version" class="block">Current Listeners: <span id="listeners">-</span></div>
-            </div>
-        </div>
-        
-        <div id="tabs" class="tabs is-centered">
-            <ul>
-                <li data-tab="request" class="is-active"><a>Request</a></li>
-                <li data-tab="history"><a>History</a></li>
-            </ul>
-        </div>
-        <div id="tab-content">
-            <section data-content="request" class="content is-active">
-                <input name="searchInput" id="searchInput" class="input is-normal is-rounded" type="text" placeholder="Filter for a song or artist!">
-                <div id="searchResults"></div>
-                <div id="requestStatus"></div>
-            </section>
-            <section data-content="history" class="content">
-                <div id="historyResults"></div>
-                <div id="historyStatus"></div>
-            </section>
-        </div>
+  <div id="tabs">
+    <ul class="nes-list">
+      <li><button class="nes-btn is-primary tab-btn active" data-tab="request">Request</button></li>
+      <li><button class="nes-btn tab-btn" data-tab="history">History</button></li>
+    </ul>
+  </div>
 
-		<footer>
-			<div>Cadence Radio <span id="release">-</span></div>
-			<div>
-				<a target="_blank" href="https://github.com/kenellorando/cadence">Source</a> • 
-				<a target="_blank" href="https://github.com/kenellorando/cadence/wiki/API-Reference">API</a>
-			</div>
-		</footer>
-	</body>
+  <div id="tab-content">
+    <section data-content="request" class="is-active">
+      <div class="nes-field">
+        <input name="searchInput" id="searchInput" class="nes-input" type="text" placeholder="Search song or artist...">
+      </div>
+      <div id="searchResults"></div>
+      <div id="requestStatus" class="nes-text"></div>
+    </section>
+    <section data-content="history">
+      <div id="historyResults"></div>
+      <div id="historyStatus" class="nes-text"></div>
+    </section>
+  </div>
+</main>
+
+<footer class="nes-container">
+  <span>Cadence Radio <span id="release">-</span></span>
+  <span>
+    <a class="nes-text is-primary" target="_blank" href="https://github.com/abzwingt-gaming/cadence">Source</a>
+  </span>
+</footer>
+
+<script src="./js/aria.js"></script>
+<script src="./js/page.js"></script>
+</body>
 </html>

--- a/src/server/public/js/aria.js
+++ b/src/server/public/js/aria.js
@@ -1,244 +1,206 @@
-var streamSrcURL = "";
+// aria.js - API communication layer. No jQuery.
 
-$(document).ready(function() {
-	getListenURL()
-	getHistory()
-	getNowPlayingMetadata()
-	getNowPlayingAlbumArt()
-	getVersion()
-	connectRadioData()
-	postSearch()
-	postRequestID()
+let streamSrcURL = '';
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchVersion();
+  fetchListenURL();
+  fetchHistory();
+  fetchNowPlayingMetadata();
+  fetchNowPlayingAlbumArt();
+  connectSSE();
+  bindSearch();
+  bindRequestButtons();
 });
 
-function getVersion() {
-	$.ajax({
-		type: "GET",
-		url: "/api/version",
-		dataType: "json",
-		success: function (data) {
-			document.getElementById("release").innerHTML = data.Version;
-		},
-		error: function () {
-			document.getElementById("release").innerHTML = "(N/A)";
-		},
-	});
+function apiFetch(url, opts = {}) {
+  return fetch(url, opts).then(r => {
+    if (!r.ok) throw new Error(r.status);
+    if (r.status === 204) return null;
+    return r.json();
+  });
 }
 
-function getNowPlayingMetadata() {
-	$.ajax({
-		type: "GET",
-		url: "/api/nowplaying/metadata",
-		dataType: "json",
-		success: function (data) {
-			$("#song").text(data.Title);
-			$("#artist").text(data.Artist);
-		},
-		error: function () {
-			$("#song").text("-");
-			$("#artist").text("-");
-		},
-	});
+function fetchVersion() {
+  apiFetch('/api/version')
+    .then(d => { document.getElementById('release').textContent = d.Version; })
+    .catch(() => { document.getElementById('release').textContent = '(N/A)'; });
 }
 
-function getNowPlayingAlbumArt() {
-	$.ajax({
-		type: "GET",
-		url: "/api/nowplaying/albumart",
-		dataType: "json",
-		success: function (data) {
-			if (data == undefined) {
-				$("#artwork").attr("src", "./static/blank.jpg");
-			} else {
-				$("#artwork").attr("src", "data:image/jpeg;base64," + data.Picture);
-			}
-		},
-		error: function () {
-			$("#artwork").attr("src", "./static/blank.jpg");
-		},
-	});
+function fetchNowPlayingMetadata() {
+  apiFetch('/api/nowplaying/metadata')
+    .then(d => {
+      document.getElementById('song').textContent   = d ? d.Title  : '-';
+      document.getElementById('artist').textContent = d ? d.Artist : '-';
+    })
+    .catch(() => {
+      document.getElementById('song').textContent   = '-';
+      document.getElementById('artist').textContent = '-';
+    });
 }
 
-function getListenURL() {
-	$.ajax({
-		type: "GET",
-		url: "/api/listenurl",
-		dataType: "json",
-		success: function (data) {
-			if (data.ListenURL == "-/-") {
-				$("#status").html("Disconnected from server.");
-			} else {
-				streamSrcURL = location.protocol + "//" + data.ListenURL;
-				document.getElementById("stream").src = streamSrcURL;
-				$("#status").html(
-					"Connected: <a href='" +
-						streamSrcURL +
-						"'>" +
-						streamSrcURL +
-						"</a>"
-				);
-			}
-		},
-		error: function () {
-			document.getElementById("stream").src = "";
-			$("#status").html("Disconnected from server.");
-		},
-	});
+function fetchNowPlayingAlbumArt() {
+  apiFetch('/api/nowplaying/albumart')
+    .then(d => {
+      const img = document.getElementById('artwork');
+      img.src = (d && d.Picture)
+        ? 'data:image/jpeg;base64,' + d.Picture
+        : './static/blank.jpg';
+    })
+    .catch(() => {
+      document.getElementById('artwork').src = './static/blank.jpg';
+    });
 }
 
-function getHistory() {
-	$.ajax({
-		type: 'GET',
-		url: "/api/history",
-		dataType: "json",
-		success: function(data) {
-			var table = "<table class='table is-striped' id='historyResults'>";
-			if (data.length === 0) {
-				document.getElementById("historyStatus").innerHTML = "No history available (yet).";
-			} else {
-				table += "<thead><tr><th>Ended</th><th>Artist</th><th>Title</th></tr></thead><tbody>"
-				data.reverse().forEach(function(song) {
-					var delta = Math.round((+(new Date()) - (new Date(String(song.Ended)))) / 1000);
-
-					var minute = 60
-					var hour = minute * 60
-					var day = hour * 24
-
-					var timeAgo;
-
-					if (delta < 30) {
-						timeAgo = 'just now';
-					} else if (delta < minute) {
-						timeAgo = delta + ' seconds ago';
-					} else if (delta < 2 * minute) {
-						timeAgo = 'a minute ago'
-					} else if (delta < hour) {
-						timeAgo = Math.floor(delta / minute) + ' minutes ago';
-					} else if (Math.floor(delta / hour) == 1) {
-						timeAgo = '1 hour ago'
-					} else if (delta < day) {
-						timeAgo = Math.floor(delta / hour) + ' hours ago';
-					}
-
-					table += "<tr><td>" + timeAgo + "</td><td>" + song.Artist + "</td><td>" + song.Title + "</td></tr>";
-				})
-				table += "</tbody>"		
-				document.getElementById("historyStatus").innerHTML = "";
-			}
-			table += "</table>";
-			document.getElementById("historyResults").innerHTML = table;
-		},
-		error: function() {	
-			document.getElementById("historyStatus").innerHTML = "Error. Could not get history.";
-		}
-	});
+function fetchListenURL() {
+  apiFetch('/api/listenurl')
+    .then(d => setStreamURL(d ? d.ListenURL : null))
+    .catch(() => setStreamURL(null));
 }
 
-function postSearch() {
-	var data = {};
-	data.search = $("#searchInput").val();
-	$.ajax({
-		type: "POST",
-		url: "/api/search",
-		contentType: "application/json",
-		data: JSON.stringify(data),
-		dataType: "json", // expects a json response
-		success: function (data) {
-			var table =
-				"<table class='table is-striped is-hoverable' id='searchResults'>";
-			if (data === null) {
-				// if no results from search
-				document.getElementById("requestStatus").innerHTML =
-					"Results: 0";
-				var input = $("#searchInput").val();
-				input = input.replace(/</g, "&lt;").replace(/>/g, "&gt;"); // Encode < and >, for error when placed back into no-results message
-			} else {
-				document.getElementById("requestStatus").innerHTML =
-					"Results: " + data.length;
-				table +=
-					"<thead><tr><th>Artist</th><th>Title</th><th>Availability</th></tr></thead><tbody>";
-				data.forEach(function (song) {
-					table +=
-						"<tr><td>" +
-						song.Artist +
-						"</td><td>" +
-						song.Title +
-						"</td><td><button class='button is-small is-light requestButton' data-id='" +
-						escape(song.ID) +
-						"'>Request</button></td></tr>";
-				});
-				table += "</tbody>";
-			}
-			table += "</table>";
-			document.getElementById("searchResults").innerHTML = table;
-		},
-		error: function () {
-			document.getElementById("requestStatus").innerHTML =
-				"Error. Could not execute search.";
-		},
-	});
+function setStreamURL(url) {
+  const statusEl = document.getElementById('status');
+  const streamEl = document.getElementById('stream');
+  if (!url || url === '-/-') {
+    streamEl.src = '';
+    statusEl.textContent = 'Waiting for stream...';
+    statusEl.className = 'nes-text is-warning';
+    return;
+  }
+  // If URL already has a protocol leave it alone; otherwise build from page protocol
+  if (!url.startsWith('http')) {
+    streamSrcURL = location.protocol + '//' + url;
+  } else {
+    streamSrcURL = url;
+  }
+  streamEl.src = streamSrcURL;
+  statusEl.innerHTML = 'Connected: <a href="' + streamSrcURL + '">' + streamSrcURL + '</a>';
+  statusEl.className = 'nes-text is-success';
 }
 
-function postRequestID() {
-	$(document).on("click", ".requestButton", function (e) {
-		var data = {};
-		data.ID = unescape(this.dataset.id);
-		$.ajax({
-			type: "POST",
-			url: "/api/request/id",
-			contentType: "application/json",
-			data: JSON.stringify(data),
-			success: function () {
-				document.getElementById("requestStatus").innerHTML =
-					"Request accepted!";
-			},
-			error: function () {
-				document.getElementById("requestStatus").innerHTML =
-					"Sorry, your request was not accepted. You may be rate limited.";
-			},
-		});
-	});
+function fetchHistory() {
+  apiFetch('/api/history')
+    .then(d => renderHistory(d))
+    .catch(() => {
+      document.getElementById('historyStatus').textContent = 'Error loading history.';
+    });
 }
 
-function connectRadioData() {
-	let eventSource = new EventSource("/api/radiodata/sse");
-	eventSource.onerror = function (event) {
-		eventSource.close();
-		setTimeout(function () {
-			connectRadioData();
-		}, 10000);
-	}
-	eventSource.addEventListener("title", function(event) {
-		$('#song').text(event.data)
-	})
-	eventSource.addEventListener("artist", function(event) {
-		$('#artist').text(event.data)
-	})
-	eventSource.addEventListener("listeners", function(event) {
-		if (event.data == -1) {
-			$("#listeners").html("N/A");
-		} else {
-			$("#listeners").html(event.data);
-		}
-	})
-	eventSource.addEventListener("title" || "artist" || "history", function() {
-		getNowPlayingAlbumArt()
-		getHistory()
-	})
-	eventSource.addEventListener("listenurl", function(event) {
-		if (event.data == "-/-") {
-			document.getElementById("stream").src = "";
-			$("#status").html("Disconnected from server.");
-		} else {
-			streamSrcURL = location.protocol + "//" + event.data;
-			document.getElementById("stream").src = streamSrcURL;
-			$("#status").html(
-				"Connected: <a href='" +
-					streamSrcURL +
-					"'>" +
-					streamSrcURL +
-					"</a>"
-			);
-		}
-	});
+function renderHistory(data) {
+  const statusEl  = document.getElementById('historyStatus');
+  const resultsEl = document.getElementById('historyResults');
+  if (!data || data.length === 0) {
+    statusEl.textContent = 'No history yet.';
+    resultsEl.innerHTML  = '';
+    return;
+  }
+  statusEl.textContent = '';
+  const rows = [...data].reverse().map(song => {
+    const delta = Math.round((Date.now() - new Date(song.Ended)) / 1000);
+    const timeAgo = formatDelta(delta);
+    return `<tr><td>${timeAgo}</td><td>${esc(song.Artist)}</td><td>${esc(song.Title)}</td></tr>`;
+  }).join('');
+  resultsEl.innerHTML =
+    `<table><thead><tr><th>Ended</th><th>Artist</th><th>Title</th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function formatDelta(s) {
+  if (s < 30)         return 'just now';
+  if (s < 60)         return s + ' sec ago';
+  if (s < 120)        return '1 min ago';
+  if (s < 3600)       return Math.floor(s/60) + ' min ago';
+  if (s < 7200)       return '1 hour ago';
+  if (s < 86400)      return Math.floor(s/3600) + ' hours ago';
+  return Math.floor(s/86400) + ' days ago';
+}
+
+function esc(str) {
+  return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+}
+
+function bindSearch() {
+  let debounceTimer;
+  const input = document.getElementById('searchInput');
+  input.addEventListener('keyup', e => {
+    if (e.key === 'Enter') { doSearch(); return; }
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(doSearch, 300);
+  });
+}
+
+function doSearch() {
+  const query = document.getElementById('searchInput').value.trim();
+  if (!query) return;
+  apiFetch('/api/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ search: query }),
+  })
+  .then(data => renderSearchResults(data))
+  .catch(() => {
+    document.getElementById('requestStatus').textContent = 'Search error.';
+  });
+}
+
+function renderSearchResults(data) {
+  const resultsEl = document.getElementById('searchResults');
+  const statusEl  = document.getElementById('requestStatus');
+  if (!data || data.length === 0) {
+    statusEl.textContent = 'No results.';
+    resultsEl.innerHTML  = '';
+    return;
+  }
+  statusEl.textContent = 'Results: ' + data.length;
+  const rows = data.map(song =>
+    `<tr>
+      <td>${esc(song.Artist)}</td>
+      <td>${esc(song.Title)}</td>
+      <td><button class="nes-btn is-primary is-small req-btn" data-id="${song.ID}">Request</button></td>
+    </tr>`
+  ).join('');
+  resultsEl.innerHTML =
+    `<table><thead><tr><th>Artist</th><th>Title</th><th></th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+
+function bindRequestButtons() {
+  document.getElementById('searchResults').addEventListener('click', e => {
+    if (!e.target.classList.contains('req-btn')) return;
+    const id = e.target.dataset.id;
+    apiFetch('/api/request/id', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ID: id }),
+    })
+    .then(() => {
+      document.getElementById('requestStatus').textContent = 'Request accepted!';
+    })
+    .catch(err => {
+      const msg = err.message === '429'
+        ? 'Rate limited. Try again later.'
+        : 'Request failed.';
+      document.getElementById('requestStatus').textContent = msg;
+    });
+  });
+}
+
+function connectSSE() {
+  const es = new EventSource('/api/radiodata/sse');
+  es.onerror = () => {
+    es.close();
+    setTimeout(connectSSE, 10000);
+  };
+  es.addEventListener('title',   e => { document.getElementById('song').textContent   = e.data; });
+  es.addEventListener('artist',  e => { document.getElementById('artist').textContent = e.data; });
+  es.addEventListener('listeners', e => {
+    document.getElementById('listeners').textContent = e.data == '-1' ? 'N/A' : e.data;
+  });
+  // On title or artist update, refresh art + history
+  ['title', 'artist'].forEach(ev => {
+    es.addEventListener(ev, () => {
+      fetchNowPlayingAlbumArt();
+      fetchHistory();
+    });
+  });
+  es.addEventListener('listenurl', e => setStreamURL(e.data));
+  es.addEventListener('history',   () => fetchHistory());
 }

--- a/src/server/public/js/page.js
+++ b/src/server/public/js/page.js
@@ -1,59 +1,50 @@
-$(document).ready(function () {
-	const stream = document.getElementById("stream");
-	const volbar = document.getElementById("volume");
+// page.js - UI interaction: play/pause, volume, tabs, theme toggle.
 
-	// Warn iOS and Safari users
-	let safariUA = /Apple/i.test(navigator.vendor);
-	let iOSUA =
-		/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-	if (iOSUA || safariUA) {
-		alert(
-			"You appear to be using an iOS device or a Safari browser. Cadence stream playback may not be compatible with your platform."
-		);
-	}
+document.addEventListener('DOMContentLoaded', () => {
+  const stream  = document.getElementById('stream');
+  const volbar  = document.getElementById('volume');
+  const playBtn = document.getElementById('playButton');
 
-	// Loads and unloads audio stream source
-	document
-		.getElementById("playButton")
-		.addEventListener("click", function () {
-			if (stream.paused) {
-				stream.src = streamSrcURL;
-				stream.load();
-				stream.play();
-				document.getElementById("playButton").innerHTML = "⏸";
-			} else {
-				stream.src = "";
-				stream.load();
-				stream.pause();
-				document.getElementById("playButton").innerHTML = "⏵";
-			}
-		});
+  // Restore volume
+  volbar.value = stream.volume = parseFloat(localStorage.getItem('volumeKey') || '0.3');
+  volbar.addEventListener('input', () => {
+    stream.volume = parseFloat(volbar.value);
+    localStorage.setItem('volumeKey', volbar.value);
+  });
 
-	// Load cached volume level, or 30%
-	volbar.value = stream.volume = localStorage.getItem("volumeKey") || 0.3;
-	// Volume bar listeners
-	$("#volume")
-		.change(function () {
-			stream.volume = this.value;
-			localStorage.setItem("volumeKey", this.value);
-		})
-		.on("input", function () {
-			stream.volume = this.value;
-			localStorage.setItem("volumeKey", this.value);
-		});
+  // Play/pause
+  playBtn.addEventListener('click', () => {
+    if (stream.paused) {
+      stream.src = streamSrcURL;
+      stream.load();
+      stream.play();
+      playBtn.innerHTML = '&#9646;&#9646;';
+    } else {
+      stream.src = '';
+      stream.load();
+      stream.pause();
+      playBtn.innerHTML = '&#9654;';
+    }
+  });
 
-	// Search keyup
-	$("#searchInput").keyup(function (event) {
-		if (event.keyCode == 13) {
-			postSearch();
-		}
-	});
-
-	$('#tabs li').on('click', function() {
-        var tab = $(this).data('tab');
-        $('#tabs li').removeClass('is-active');
-        $(this).addClass('is-active');
-        $('#tab-content section').removeClass('is-active');
-        $('section[data-content="' + tab + '"]').addClass('is-active');
+  // Tabs
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active', 'is-primary'));
+      document.querySelectorAll('#tab-content section').forEach(s => s.classList.remove('is-active'));
+      btn.classList.add('active', 'is-primary');
+      document.querySelector(`section[data-content="${btn.dataset.tab}"]`).classList.add('is-active');
     });
+  });
+
+  // Theme toggle - persisted in localStorage
+  const html = document.documentElement;
+  const savedTheme = localStorage.getItem('theme') || 'dark';
+  html.setAttribute('data-theme', savedTheme);
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    const current = html.getAttribute('data-theme');
+    const next    = current === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
 });

--- a/src/server/routes.go
+++ b/src/server/routes.go
@@ -1,69 +1,33 @@
+// routes.go
+
 package main
 
 import (
-	"encoding/json"
 	"net/http"
-	"time"
 
-	eventsource "gopkg.in/antage/eventsource.v1"
+	"gopkg.in/antage/eventsource.v1"
 )
 
-var radiodata_sse eventsource.EventSource
+var radiodata_sse = eventsource.New(nil, nil)
 
-func routes() http.Handler {
-	radiodata_sse = eventsource.New(nil, func(req *http.Request) [][]byte {
-		return [][]byte{}
-	})
-
-	mux := http.NewServeMux()
-
-	// Health
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-		type health struct {
-			Status   string `json:"status"`
-			Redis    bool   `json:"redis"`
-			Postgres bool   `json:"postgres"`
-			Uptime   string `json:"uptime"`
-		}
-		dbOK := dbp != nil && dbp.Ping() == nil
-		status := "ok"
-		if !dbOK {
-			status = "degraded"
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(health{
-			Status:   status,
-			Redis:    redisAvailable,
-			Postgres: dbOK,
-			Uptime:   time.Since(startTime).Round(time.Second).String(),
-		})
-	})
-	mux.HandleFunc("/ready", Ready())
-
-	// Static files
-	fs := http.FileServer(http.Dir(c.RootPath + "public"))
-	mux.Handle("/", fs)
-
-	// SSE
-	mux.Handle("/api/radiodata/sse", radiodata_sse)
-
-	// Public API
-	mux.Handle("/api/search", http.HandlerFunc(Search()))
-	mux.Handle("/api/request/id", rateLimitRequest(http.HandlerFunc(RequestID())))
-	mux.Handle("/api/request/bestmatch", rateLimitRequest(http.HandlerFunc(RequestBestMatch())))
-	mux.Handle("/api/nowplaying/metadata", http.HandlerFunc(NowPlayingMetadata()))
-	mux.Handle("/api/nowplaying/albumart", rateLimitArt(http.HandlerFunc(NowPlayingAlbumArt())))
-	mux.Handle("/api/history", http.HandlerFunc(History()))
-	mux.Handle("/api/listenurl", http.HandlerFunc(ListenURL()))
-	mux.Handle("/api/listeners", http.HandlerFunc(Listeners()))
-	mux.Handle("/api/bitrate", http.HandlerFunc(Bitrate()))
-	mux.Handle("/api/version", http.HandlerFunc(Version()))
-
+func routes() *http.ServeMux {
+	r := http.NewServeMux()
+	r.Handle("/api/radiodata/sse",       radiodata_sse)
+	r.Handle("/api/search",              Search())
+	r.Handle("/api/request/id",          rateLimitRequest(RequestID()))
+	r.Handle("/api/request/bestmatch",   rateLimitRequest(RequestBestMatch()))
+	r.Handle("/api/nowplaying/metadata", NowPlayingMetadata())
+	r.Handle("/api/nowplaying/albumart", rateLimitArt(NowPlayingAlbumArt()))
+	r.Handle("/api/history",             History())
+	r.Handle("/api/listenurl",           ListenURL())
+	r.Handle("/api/listeners",           Listeners())
+	r.Handle("/api/bitrate",             Bitrate())
+	r.Handle("/api/version",             Version())
+	r.Handle("/healthz",                 Healthz())
+	r.Handle("/ready",                   Ready())
 	if c.DevMode {
-		mux.Handle("/api/dev/skip", http.HandlerFunc(DevSkip()))
+		r.Handle("/api/dev/skip", DevSkip())
 	}
-
-	return mux
+	r.Handle("/", http.FileServer(http.Dir(c.RootPath+"./public/")))
+	return r
 }
-
-var startTime = time.Now()

--- a/src/server/routes.go
+++ b/src/server/routes.go
@@ -1,33 +1,69 @@
-// routes.go
-// Routes incoming requests to functions written in api.go
-
 package main
 
 import (
+	"encoding/json"
 	"net/http"
+	"time"
 
-	"gopkg.in/antage/eventsource.v1"
+	eventsource "gopkg.in/antage/eventsource.v1"
 )
 
-var radiodata_sse = eventsource.New(nil, nil)
+var radiodata_sse eventsource.EventSource
 
-func routes() *http.ServeMux {
-	r := http.NewServeMux()
-	r.Handle("/api/radiodata/sse", radiodata_sse)
-	r.Handle("/api/search", Search())
-	r.Handle("/api/request/id", rateLimitRequest(RequestID()))
-	r.Handle("/api/request/bestmatch", rateLimitRequest(RequestBestMatch()))
-	r.Handle("/api/nowplaying/metadata", NowPlayingMetadata())
-	r.Handle("/api/nowplaying/albumart", rateLimitArt(NowPlayingAlbumArt()))
-	r.Handle("/api/history", History())
-	r.Handle("/api/listenurl", ListenURL())
-	r.Handle("/api/listeners", Listeners())
-	r.Handle("/api/bitrate", Bitrate())
-	r.Handle("/api/version", Version())
-	r.Handle("/ready", Ready())
+func routes() http.Handler {
+	radiodata_sse = eventsource.New(nil, func(req *http.Request) [][]byte {
+		return [][]byte{}
+	})
+
+	mux := http.NewServeMux()
+
+	// Health
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		type health struct {
+			Status   string `json:"status"`
+			Redis    bool   `json:"redis"`
+			Postgres bool   `json:"postgres"`
+			Uptime   string `json:"uptime"`
+		}
+		dbOK := dbp != nil && dbp.Ping() == nil
+		status := "ok"
+		if !dbOK {
+			status = "degraded"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(health{
+			Status:   status,
+			Redis:    redisAvailable,
+			Postgres: dbOK,
+			Uptime:   time.Since(startTime).Round(time.Second).String(),
+		})
+	})
+	mux.HandleFunc("/ready", Ready())
+
+	// Static files
+	fs := http.FileServer(http.Dir(c.RootPath + "public"))
+	mux.Handle("/", fs)
+
+	// SSE
+	mux.Handle("/api/radiodata/sse", radiodata_sse)
+
+	// Public API
+	mux.Handle("/api/search", http.HandlerFunc(Search()))
+	mux.Handle("/api/request/id", rateLimitRequest(http.HandlerFunc(RequestID())))
+	mux.Handle("/api/request/bestmatch", rateLimitRequest(http.HandlerFunc(RequestBestMatch())))
+	mux.Handle("/api/nowplaying/metadata", http.HandlerFunc(NowPlayingMetadata()))
+	mux.Handle("/api/nowplaying/albumart", rateLimitArt(http.HandlerFunc(NowPlayingAlbumArt())))
+	mux.Handle("/api/history", http.HandlerFunc(History()))
+	mux.Handle("/api/listenurl", http.HandlerFunc(ListenURL()))
+	mux.Handle("/api/listeners", http.HandlerFunc(Listeners()))
+	mux.Handle("/api/bitrate", http.HandlerFunc(Bitrate()))
+	mux.Handle("/api/version", http.HandlerFunc(Version()))
+
 	if c.DevMode {
-		r.Handle("/api/dev/skip", DevSkip())
+		mux.Handle("/api/dev/skip", http.HandlerFunc(DevSkip()))
 	}
-	r.Handle("/", http.FileServer(http.Dir(c.RootPath+"./public/")))
-	return r
+
+	return mux
 }
+
+var startTime = time.Now()


### PR DESCRIPTION
…ag tolerance, public stream URL

- Redis: add CSERVER_REDISPASSWORD + CSERVER_REDISDB env vars, optional with graceful degradation
- Postgres: replace destructive DROP DATABASE with DROP TABLE IF NOT EXISTS, no cold-sleep startup,
  retry loop with timeout, continue on tag error instead of aborting scan, use filename as title
  fallback for empty tags, support .m4a/.opus/.aac extensions
- IcecastMonitor: strip scheme from address at startup, fix listenurl fmt.Sprintf bug,
  guard FlushDB behind redisAvailable, separate internal status URL from public stream URL
- Config: add CSERVER_PUBLIC_STREAM_URL, CSERVER_ICECAST_STATUS_URL, CSERVER_REDISPASSWORD,
  CSERVER_REDISDB env vars; add /healthz endpoint
- go.mod: add modernc.org/sqlite for optional SQLite support (future)
- Routes: add /healthz